### PR TITLE
Query Construction changes

### DIFF
--- a/rcsbapi/data/schema.py
+++ b/rcsbapi/data/schema.py
@@ -422,8 +422,21 @@ class Schema:
         return_data_name = [name.split('.')[-1] for name in return_data_list]
         attr_list = self.root_dict[input_type]
         attr_name = [id["name"] for id in attr_list]
+        attr_kind = {attr["name"]: attr["kind"] for attr in attr_list}
+
         if not all(key in attr_name for key in input_ids.keys()):
-            raise ValueError(f"Input IDs keys do not match attribute names: {input_ids.keys()} vs {attr_name}")  
+                raise ValueError(f"Input IDs keys do not match attribute names: {input_ids.keys()} vs {attr_name}")
+
+        for key, value in input_ids.items():
+            if attr_kind[key] == "SCALAR":
+                if not isinstance(value, str):
+                    raise ValueError(f"Input ID for {key} should be a single string")
+            elif attr_kind[key] == "LIST":
+                if not isinstance(value, list):
+                    raise ValueError(f"Input ID for {key} should be a list of strings")
+                if not all(isinstance(item, str) for item in value):
+                    raise ValueError(f"Input ID for {key} should be a list of strings") 
+
         field_names = {}
 
         start_node_index = None

--- a/rcsbapi/data/testschema.py
+++ b/rcsbapi/data/testschema.py
@@ -75,11 +75,11 @@ class SchemaTests(unittest.TestCase):
 
     def testConstructQueryRustworkX(self):
         with self.subTest(msg="1.  singular input_type (entry)"):
-            query = SCHEMA._Schema__construct_query_rustworkx(input_ids="4HHB", input_type="entry", return_data_list=["exptl"])
+            query = SCHEMA._Schema__construct_query_rustworkx(input_ids={"entry_id": "4HHB"}, input_type="entry", return_data_list=["exptl"])
             response_json = requests.post(headers={"Content-Type": "application/graphql"}, data=query, url=pdb_url).json()
             self.assertNotIn('errors', response_json.keys())
         with self.subTest(msg="2. plural input_type (entries)"):
-            query = SCHEMA._Schema__construct_query_rustworkx(input_ids=["4HHB", "1IYE"], input_type="entries", return_data_list=["exptl"])
+            query = SCHEMA._Schema__construct_query_rustworkx(input_ids= {"entry_ids": ["4HHB", "1IYE"]}, input_type="entries", return_data_list=["exptl"])
             response_json = requests.post(headers={"Content-Type": "application/graphql"}, data=query, url=pdb_url).json()
             self.assertNotIn('errors', response_json.keys())
         with self.subTest(msg="3. two arguments (polymer_entity_instance)"): #TODO: do I have to test mult arg + plural?
@@ -87,21 +87,21 @@ class SchemaTests(unittest.TestCase):
             response_json = requests.post(headers={"Content-Type": "application/graphql"}, data=query, url=pdb_url).json()
             self.assertNotIn('errors', response_json.keys())
         with self.subTest(msg="4. three arguments (interface)"):
-            query = SCHEMA._Schema__construct_query_rustworkx(input_ids={'assembly_id': "1", "interface_id": "1", "entry_id": "4HHB"}, input_type="interface", return_data_list=["rcsb_id"])
+            query = SCHEMA._Schema__construct_query_rustworkx(input_ids={'assembly_id': "1", "interface_id": "1", "entry_id": "4HHB"}, input_type="interface", return_data_list=["CoreInterface.rcsb_id"])
             response_json = requests.post(headers={"Content-Type": "application/graphql"}, data=query, url=pdb_url).json()
             self.assertNotIn('errors', response_json.keys())
         with self.subTest(msg="5. request multiple return fields"):
-            query = SCHEMA._Schema__construct_query_rustworkx(input_ids="4HHB", input_type="entry", return_data_list=["exptl","rcsb_polymer_instance_annotation"])
+            query = SCHEMA._Schema__construct_query_rustworkx(input_ids={"entry_id": "4HHB"}, input_type="entry", return_data_list=["exptl","rcsb_polymer_instance_annotation"])
             response_json = requests.post(headers={"Content-Type": "application/graphql"}, data=query, url=pdb_url).json()
             self.assertNotIn('errors', response_json.keys())
         with self.subTest(msg="6. request scalar field"):
-            query = SCHEMA._Schema__construct_query_rustworkx(input_ids="4HHB", input_type="entry", return_data_list=["rcsb_id"])
+            query = SCHEMA._Schema__construct_query_rustworkx(input_ids={"entry_id": "4HHB"}, input_type="entry", return_data_list=["rcsb_id"])
             response_json = requests.post(headers={"Content-Type": "application/graphql"}, data=query, url=pdb_url).json()
             self.assertNotIn('errors', response_json.keys())
         # Test error handling
         with self.subTest(msg="7. too many input ids passed in"):
             with self.assertRaises(Exception):
-                SCHEMA._Schema__construct_query_rustworkx(input_ids=["4HHB","1IYE"], input_type="entry", return_data_list=["rcsb_id"])
+                SCHEMA._Schema__construct_query_rustworkx(input_ids={"entry_id": ["4HHB","1IYE"]}, input_type="entry", return_data_list=["Entry.rcsb_id"])
         with self.subTest(msg="too few inputs keys provided"):
             with self.assertRaises(Exception):
                 SCHEMA._Schema__construct_query_rustworkx(input_ids={"entry_id": "4HHB"}, input_type="polymer_entity_instance", return_data_list=["exptl"])
@@ -113,7 +113,7 @@ class SchemaTests(unittest.TestCase):
                 SCHEMA._Schema__construct_query_rustworkx(input_ids={'assembly_id': "1", "interface_id": "1", "entry_id": "4HHB"}, input_type="interface", return_data_list=["exptl"])
         with self.subTest(msg="11. return data not specific enough"):
             with self.assertRaises(Exception):
-                SCHEMA._Schema__construct_query_rustworkx(input_ids="4HHB", input_type="entry", return_data_list=["id"])
+                SCHEMA._Schema__construct_query_rustworkx(input_ids="4HHB", input_type="entry", return_data_list=["Entry.id"])
 
 
 def buildSchema():


### PR DESCRIPTION
- handles error when `input_ids` is a single string when excepting a list
- handles error when `input_ids` is a list of strings when excepting a string
- accepts `input_ids` as a dictionary with key as argument names (entry_id, asym_id) and values as ids ("4HHB" or ["4HHB", "1IYE"]
- edited test file to accept new input format
- read and construct query based on dot notation for `return_data_list` when requesting redundant data fields (Entry.id, CoreInterface.rcsb_id)
- fixed missing brackets in query string