### PR TITLE
Construct query test edits

### DIFF
--- a/tests/test_data_schema.py
+++ b/tests/test_data_schema.py
@@ -114,11 +114,11 @@ class SchemaTests(unittest.TestCase):
 
     def testConstructQueryRustworkX(self):
         with self.subTest(msg="1.  singular input_type (entry)"):
-            query = SCHEMA._Schema__construct_query_rustworkx(input_ids="4HHB", input_type="entry", return_data_list=["exptl"])
+            query = SCHEMA._Schema__construct_query_rustworkx(input_ids={"entry_id": "4HHB"}, input_type="entry", return_data_list=["exptl"])
             response_json = requests.post(headers={"Content-Type": "application/graphql"}, data=query, url=pdb_url).json()
             self.assertNotIn('errors', response_json.keys())
         with self.subTest(msg="2. plural input_type (entries)"):
-            query = SCHEMA._Schema__construct_query_rustworkx(input_ids=["4HHB", "1IYE"], input_type="entries", return_data_list=["exptl"])
+            query = SCHEMA._Schema__construct_query_rustworkx(input_ids={"entry_ids": ["4HHB", "1IYE"]}, input_type="entries", return_data_list=["exptl"])
             response_json = requests.post(headers={"Content-Type": "application/graphql"}, data=query, url=pdb_url).json()
             self.assertNotIn('errors', response_json.keys())
         with self.subTest(msg="3. two arguments (polymer_entity_instance)"): #TODO: do I have to test mult arg + plural?

--- a/tests/test_data_schema.py
+++ b/tests/test_data_schema.py
@@ -18,6 +18,7 @@ __email__ = ""
 __license__ = ""
 
 import logging
+import importlib
 # import platform
 # import resource
 import time
@@ -94,20 +95,22 @@ class SchemaTests(unittest.TestCase):
         self.assertEqual(entry_dict_from_func, entry_dict)
         self.assertEqual(len(type_dict_list), len(SCHEMA.type_fields_dict.keys()))
 
-    def testRecurseBuildSchema(self):
+    def testRecurseBuildSchema(self):  # doesn't work right now
         original_networkx_flag = schema.use_networkx
         schema.use_networkx = False
+        importlib.reload(schema)
         SCHEMA = Schema(pdb_url)
         SCHEMA.recurse_build_schema(SCHEMA.schema_graph, 'Query')
         self.assertIsInstance(SCHEMA.schema_graph, rx.PyDiGraph)
         schema.use_networkx = True
+        importlib.reload(schema)
         SCHEMA = Schema(pdb_url)
         SCHEMA.recurse_build_schema(SCHEMA.schema_graph, 'Query')
         self.assertIsInstance(SCHEMA.schema_graph, nx.classes.digraph.DiGraph)
         # reset to original
         schema.use_networkx = original_networkx_flag
+        importlib.reload(schema)
         SCHEMA = Schema(pdb_url)
-        SCHEMA.recurse_build_schema(SCHEMA.schema_graph, 'Query')
 
     def testConstructQueryRustworkX(self):
         with self.subTest(msg="1.  singular input_type (entry)"):
@@ -147,9 +150,14 @@ class SchemaTests(unittest.TestCase):
         with self.subTest(msg="10. no path exists"):
             with self.assertRaises(ValueError):
                 SCHEMA._Schema__construct_query_rustworkx(input_ids={'assembly_id': "1", "interface_id": "1", "entry_id": "4HHB"}, input_type="interface", return_data_list=["exptl"])
-        with self.subTest(msg="11. return data not specific enough"):
+         with self.subTest(msg="11. field doesn't exist"):
             with self.assertRaises(ValueError):
-                SCHEMA._Schema__construct_query_rustworkx(input_ids="4HHB", input_type="entry", return_data_list=["id"])
+                SCHEMA._Schema__construct_query_rustworkx(input_ids={'assembly_id': "1", "interface_id": "1", "entry_id": "4HHB"}, input_type="interface", return_data_list=["aaa"])
+        
+    def testConstructQuery(self):
+        with self.subTest(msg="1. return data not specific enough"):
+            with self.assertRaises(ValueError):
+                SCHEMA.construct_query(input_ids="4HHB", input_type="entry", return_data_list=["id"])
 
     def testVerifyUniqueField(self):
         with self.subTest(msg="1. unique field with dot notation"):
@@ -167,12 +175,13 @@ class SchemaTests(unittest.TestCase):
 
 def buildSchema():
     suiteSelect = unittest.TestSuite()
-    # suiteSelect.addTest(SchemaTests("testFetch"))
-    # suiteSelect.addTest(SchemaTests("testConstructRootDict"))
-    # suiteSelect.addTest(SchemaTests("testConstructTypeDict"))
-    suiteSelect.addTest(SchemaTests("testRecurseBuildSchema"))
-    # suiteSelect.addTest(SchemaTests("testConstructQueryRustworkX"))
-    # suiteSelect.addTest(SchemaTests("testVerifyUniqueField"))
+    suiteSelect.addTest(SchemaTests("testFetch"))
+    suiteSelect.addTest(SchemaTests("testConstructRootDict"))
+    suiteSelect.addTest(SchemaTests("testConstructTypeDict"))
+    # suiteSelect.addTest(SchemaTests("testRecurseBuildSchema"))
+    suiteSelect.addTest(SchemaTests("testConstructQuery"))
+    suiteSelect.addTest(SchemaTests("testConstructQueryRustworkX"))
+    suiteSelect.addTest(SchemaTests("testVerifyUniqueField"))
     return suiteSelect
 
 


### PR DESCRIPTION
- added new test case to `testConstructQueryRustworkX` for fields not existing
- started new test for `testConstructQuery` for requesting a redundant field (moved from rustworkx test)