### PR TITLE
Recursive function to construct query

### DIFF
--- a/rcsbapi/data/schema.py
+++ b/rcsbapi/data/schema.py
@@ -353,7 +353,7 @@ class Schema:
                     if name.split(".")[1].lower() == return_data_name:
                         valid_field_list.append(name)
         return valid_field_list
-    
+
     def recurse_fields(self, fields, field_map, indent=2):
         query_str = ""
         for field, value in fields.items():
@@ -379,7 +379,7 @@ class Schema:
                     query_str += " " * indent + "}\n"
                     self.closed_brackets += 1
         return query_str
-    
+
     def construct_query(self, input_ids: Union[Dict[str, str], List[str]], input_type: str, return_data_list: List[str]):
         for return_field in return_data_list:
             if self.verify_unique_field(return_field) is True:

--- a/rcsbapi/data/schema.py
+++ b/rcsbapi/data/schema.py
@@ -537,8 +537,9 @@ class Schema:
 
         # Get all shortest paths from the start node to each target node
         all_paths = {target_node: rx.digraph_all_shortest_paths(self.schema_graph, start_node_index, target_node) for target_node in target_node_indices}
-        if any(not value for value in all_paths.values()):
-            raise ValueError(f"The return data requested does not match the input type {input_type}")
+        for return_data in return_data_list:
+            if any(not value for value in all_paths.values()):
+                raise ValueError(f"You can't access {return_data} from input type {input_type}")
         final_fields = {}
 
         for target_node in target_node_indices:

--- a/rcsbapi/data/schema.py
+++ b/rcsbapi/data/schema.py
@@ -449,7 +449,7 @@ class Schema:
                     inputDict["entry_id"] = str(re.findall(r"^[^-]+", input_ids[0])[0])
                     inputDict["assembly_id"] = str(re.findall(r"-(.*)\.", input_ids[0])[0])
                     inputDict["interface_id"] = str(re.findall(r"[^.]+$", input_ids[0])[0])
-            elif (re.match(r"^(MA|AF)_.*$", single_id) or re.match(r"^[1-9][A-Z]{3}$", single_id)) and input_type in ["entries", "entry"]:
+            elif (re.match(r"^(MA|AF)_[A-Za-z0-9]*$", single_id) or re.match(r"^[1-9][A-Z]{3}$", single_id)) and input_type in ["entries", "entry"]:
                 attr_name = [single_id["name"] for single_id in attr_list]
                 if len(input_ids) == 1:
                     inputDict["entry_id"] = str(input_ids[0])

--- a/rcsbapi/data/schema.py
+++ b/rcsbapi/data/schema.py
@@ -352,6 +352,8 @@ class Schema:
                 query_str += " " * indent + subfield
                 if idx < len(mapped_path) - 1 or (isinstance(value, list) and value):
                     query_str += "{\n"
+                else:
+                    query_str += "\n"
                 indent += 2 if idx == 0 else 0
             if isinstance(value, list):
                 if value:  # Only recurse if the list is not empty
@@ -572,6 +574,7 @@ class Schema:
         query += ") {\n"
         query += self.recurse_fields(final_fields, field_names)
         query += " " + "}\n}\n"
+        print(query)
         return query
 
 

--- a/rcsbapi/data/schema.py
+++ b/rcsbapi/data/schema.py
@@ -459,7 +459,7 @@ class Schema:
                     inputDict["entry_id"] = str(re.findall(r"^[^_]+", input_ids[0])[0])
                     inputDict["entity_id"] = str(re.findall(r"[^_]+$", input_ids[0])[0])
             else:
-                raise ValueError(f"Invalid ID format: {single_id}")
+                raise ValueError(f"Invalid ID format for {input_type}: {single_id}")
             for attr in attr_name:
                 # print("attr: ", attr)
                 if attr not in inputDict:

--- a/rcsbapi/data/schema.py
+++ b/rcsbapi/data/schema.py
@@ -59,8 +59,6 @@ class Schema:
         self.field_names_list = []
         self.root_introspection = self.request_root_types(pdb_url)
         self.root_dict = {}
-        self.opened_brackets = 0
-        self.closed_brackets = 0
         self.schema = self.fetch_schema(self.pdb_url)
 
         if use_networkx:
@@ -354,7 +352,6 @@ class Schema:
                 query_str += " " * indent + subfield
                 if idx < len(mapped_path) - 1 or (isinstance(value, list) and value):
                     query_str += "{\n"
-                    self.opened_brackets += 1
                 indent += 2 if idx == 0 else 0
             if isinstance(value, list):
                 if value:  # Only recurse if the list is not empty
@@ -368,7 +365,6 @@ class Schema:
             for idx, subfield in enumerate(mapped_path):
                 if idx < len(mapped_path) - 1 or (isinstance(value, list) and value):
                     query_str += " " * indent + "}\n"
-                    self.closed_brackets += 1
         return query_str
 
     def construct_query(self, input_ids: Union[Dict[str, str], List[str]], input_type: str, return_data_list: List[str]):
@@ -565,8 +561,6 @@ class Schema:
                         field_node_name = node_data.name
                         field_names[target_node_name].append(field_node_name)
         query = "{ " + input_type + "("
-        self.opened_brackets = 1
-        self.closed_brackets = 0
 
         for i, attr in enumerate(attr_name):
             if isinstance(inputDict[attr], list):
@@ -576,11 +570,8 @@ class Schema:
             if i < len(attr_name) - 1:
                 query += ", "
         query += ") {\n"
-        self.opened_brackets += 1
-
         query += self.recurse_fields(final_fields, field_names)
-        query += " " * (self.opened_brackets - self.closed_brackets) + "}\n" * (self.opened_brackets - self.closed_brackets)
-
+        query += " " + "}\n}\n"
         return query
 
 

--- a/rcsbapi/data/schema.py
+++ b/rcsbapi/data/schema.py
@@ -2,23 +2,14 @@ import re
 import logging
 from typing import List, Dict, Union
 import requests
+import networkx as nx
 
 use_networkx = False
 try:
     import rustworkx as rx
-
     logging.info("Using  rustworkx")
 except ImportError:
     use_networkx = True
-
-if use_networkx is True:
-    try:
-        import networkx as nx
-
-        logging.info("Using  networkx")
-    except ImportError:
-        print("Error: Neither rustworkx nor networkx is installed.")
-        exit(1)
 
 pdbUrl = "https://data.rcsb.org/graphql"
 

--- a/tests/test_data_schema.py
+++ b/tests/test_data_schema.py
@@ -186,6 +186,9 @@ class SchemaTests(unittest.TestCase):
         with self.subTest(msg="20. nested query"):
             query = SCHEMA._Schema__construct_query_rustworkx(input_type="interfaces", return_data_list=["rcsb_interface_partner"], input_ids=["MA_MACOFFESLACC100000G1I2-1.1", "7XIW-1.2"])
             self.assertNotIn("errors", response_json.keys())
+        with self.subTest(msg="20. requesting scalars under same field"):
+            query = SCHEMA._Schema__construct_query_rustworkx(input_type="entry", return_data_list=["Exptl.method", "Exptl.details"], input_ids=["4HHB"])
+            self.assertNotIn("errors", response_json.keys())
 
     def testConstructQuery(self):
         with self.subTest(msg="1. return data not specific enough"):

--- a/tests/test_data_schema.py
+++ b/tests/test_data_schema.py
@@ -183,6 +183,9 @@ class SchemaTests(unittest.TestCase):
         with self.subTest(msg="19. using id_list with a singular type"):
             query = SCHEMA._Schema__construct_query_rustworkx(input_type="entry", return_data_list=["exptl"], input_ids=["4HHB"])
             self.assertNotIn("errors", response_json.keys())
+        with self.subTest(msg="20. nested query"):
+            query = SCHEMA._Schema__construct_query_rustworkx(input_type="interfaces", return_data_list=["rcsb_interface_partner"], input_ids=["MA_MACOFFESLACC100000G1I2-1.1", "7XIW-1.2"])
+            self.assertNotIn("errors", response_json.keys())
 
     def testConstructQuery(self):
         with self.subTest(msg="1. return data not specific enough"):

--- a/tests/test_data_schema.py
+++ b/tests/test_data_schema.py
@@ -182,13 +182,20 @@ class SchemaTests(unittest.TestCase):
             self.assertNotIn("errors", response_json.keys())
         with self.subTest(msg="19. using id_list with a singular type"):
             query = SCHEMA._Schema__construct_query_rustworkx(input_type="entry", return_data_list=["exptl"], input_ids=["4HHB"])
+            response_json = requests.post(headers={"Content-Type": "application/graphql"}, data=query, url=pdbUrl).json()
             self.assertNotIn("errors", response_json.keys())
         with self.subTest(msg="20. nested query"):
             query = SCHEMA._Schema__construct_query_rustworkx(input_type="interfaces", return_data_list=["rcsb_interface_partner"], input_ids=["MA_MACOFFESLACC100000G1I2-1.1", "7XIW-1.2"])
+            response_json = requests.post(headers={"Content-Type": "application/graphql"}, data=query, url=pdbUrl).json()
             self.assertNotIn("errors", response_json.keys())
         with self.subTest(msg="20. requesting scalars under same field"):
             query = SCHEMA._Schema__construct_query_rustworkx(input_type="entry", return_data_list=["Exptl.method", "Exptl.details"], input_ids=["4HHB"])
+            response_json = requests.post(headers={"Content-Type": "application/graphql"}, data=query, url=pdbUrl).json()
             self.assertNotIn("errors", response_json.keys())
+        with self.subTest(msg="20. wrong entry id for entry type"):
+            with self.assertRaises(ValueError):
+                SCHEMA._Schema__construct_query_rustworkx(input_type="entry", return_data_list=["Exptl.method", "Exptl.details"], input_ids=["MA_MACOFFESLACC100000G1I2-1.1"])
+            
 
     def testConstructQuery(self):
         with self.subTest(msg="1. return data not specific enough"):

--- a/tests/test_data_schema.py
+++ b/tests/test_data_schema.py
@@ -195,7 +195,6 @@ class SchemaTests(unittest.TestCase):
         with self.subTest(msg="20. wrong entry id for entry type"):
             with self.assertRaises(ValueError):
                 SCHEMA._Schema__construct_query_rustworkx(input_type="entry", return_data_list=["Exptl.method", "Exptl.details"], input_ids=["MA_MACOFFESLACC100000G1I2-1.1"])
-            
 
     def testConstructQuery(self):
         with self.subTest(msg="1. return data not specific enough"):


### PR DESCRIPTION
- `recurse_fields()`: a recursive function that constructs a query using the necessary fields and subfields
- For each field in the `fields` dictionary, the method:
    - retrieves the field's path in the graph using `field_map`
    - checks if the field has subfields (i.e., if it's a complex type). If so, it recursively calls itself with the subfields and the updated indent level.
    - If the field is a scalar type, it simply adds the field name to the query string.
- For each subfield, the method:
    - Recursively calls itself with the subfield's path and the updated indent level.
    - Adds the subfield's name and value to the query string, indented according to the indent level.
- Base Case: when the `value` is a scalar type
- More test cases added 