### PR TITLE
Import `annotations` in const.py for Python 3.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+## v1.0.1 (2025-01-17)
+
+- Add import to `const.py` for compatibility with Python 3.8
+- Update search schemas: 1.47.7 -> 1.48.0
 
 ## v1.0.0 (2024-11-6)
 

--- a/azure-template-publish-job.yml
+++ b/azure-template-publish-job.yml
@@ -12,9 +12,9 @@ jobs:
 - job: ${{ format('publish_{0}_{1}', parameters.tox, parameters.os) }}
   pool:
     ${{ if eq(parameters.os, 'macos') }}:
-      vmImage: 'macOS-13'
+      vmImage: 'macOS-15'
     ${{ if eq(parameters.os, 'linux') }}:
-      vmImage: 'ubuntu-20.04'
+      vmImage: 'ubuntu-latest'
   dependsOn:
   - ${{ format('build_test_{0}_{1}', parameters.tox, parameters.os) }}
   condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'), eq(variables['Build.SourceBranch'], 'refs/heads/master'))

--- a/azure-template-tox-job.yml
+++ b/azure-template-tox-job.yml
@@ -13,9 +13,9 @@ jobs:
   timeoutInMinutes: 0
   pool:
     ${{ if eq(parameters.os, 'macos') }}:
-      vmImage: 'macOS-13'
+      vmImage: 'macOS-15'
     ${{ if eq(parameters.os, 'linux') }}:
-      vmImage: 'ubuntu-20.04'
+      vmImage: 'ubuntu-latest'
 
   variables:
     - group: py-shared-variables
@@ -36,7 +36,7 @@ jobs:
       - bash: |
           set -e
           ls -la /Applications/Xcode*
-          sudo xcode-select --switch /Applications/Xcode_14.2.app/Contents/Developer
+          sudo xcode-select --switch /Applications/Xcode_16.app/Contents/Developer
           which g++
           c++ --version
         displayName: "setup Xcode"

--- a/rcsbapi/__init__.py
+++ b/rcsbapi/__init__.py
@@ -2,7 +2,7 @@ __docformat__ = "restructuredtext en"
 __author__ = "Dennis Piehl"
 __email__ = "dennis.piehl@rcsb.org"
 __license__ = "MIT"
-__version__ = "1.0.0"
+__version__ = "1.0.1"
 
 __path__ = __import__("pkgutil").extend_path(__path__, __name__)
 

--- a/rcsbapi/const.py
+++ b/rcsbapi/const.py
@@ -6,6 +6,7 @@ including API endpoints, search services, and schema URLs. The values are
 immutable and protected from modification during runtime.
 """
 
+from __future__ import annotations
 from dataclasses import dataclass
 from types import MappingProxyType
 from typing import List

--- a/rcsbapi/search/resources/chemical_schema.json
+++ b/rcsbapi/search/resources/chemical_schema.json
@@ -3684,7 +3684,7 @@
                             "context": "brief"
                         }
                     ],
-                    "rcsb_current_maximum_value": 1730246400000.0,
+                    "rcsb_current_maximum_value": 1736208000000.0,
                     "rcsb_current_minimum_value": 711158400000.0
                 },
                 "initial_release_date": {
@@ -3713,7 +3713,7 @@
                             "priority_order": 20
                         }
                     ],
-                    "rcsb_current_maximum_value": 1730851200000.0,
+                    "rcsb_current_maximum_value": 1736899200000.0,
                     "rcsb_current_minimum_value": 105235200000.0
                 },
                 "release_status": {
@@ -5163,5 +5163,5 @@
     "$schema": "http://json-schema.org/draft-04/schema#",
     "title": "Chemical Text Service Metadata",
     "description": "",
-    "$comment": "Schema version: 1.47.7"
+    "$comment": "Schema version: 1.48.0"
 }

--- a/rcsbapi/search/resources/structure_schema.json
+++ b/rcsbapi/search/resources/structure_schema.json
@@ -865,9 +865,7 @@
                                 "text": "Count (Branched Instance Feature Summary)",
                                 "context": "brief"
                             }
-                        ],
-                        "rcsb_current_maximum_value": 1236.0,
-                        "rcsb_current_minimum_value": 1.0
+                        ]
                     },
                     "coverage": {
                         "type": "number",
@@ -888,9 +886,7 @@
                                 "text": "Coverage (Branched Instance Feature Summary)",
                                 "context": "brief"
                             }
-                        ],
-                        "rcsb_current_maximum_value": 0.0,
-                        "rcsb_current_minimum_value": 0.0
+                        ]
                     },
                     "maximum_length": {
                         "type": "integer",
@@ -4050,7 +4046,7 @@
                                 "context": "brief"
                             }
                         ],
-                        "rcsb_current_maximum_value": 1727913600000.0,
+                        "rcsb_current_maximum_value": 1732233600000.0,
                         "rcsb_current_minimum_value": -29926281600000.0
                     },
                     "pdbx_frequency": {
@@ -7083,7 +7079,7 @@
                             }
                         ],
                         "rcsb_current_maximum_value": 50000.0,
-                        "rcsb_current_minimum_value": -20000.0
+                        "rcsb_current_minimum_value": -25000.0
                     },
                     "nominal_defocus_min": {
                         "type": "number",
@@ -7103,7 +7099,7 @@
                             }
                         ],
                         "rcsb_current_maximum_value": 16000.0,
-                        "rcsb_current_minimum_value": -8000.0
+                        "rcsb_current_minimum_value": -15000.0
                     },
                     "nominal_magnification": {
                         "type": "integer",
@@ -7376,7 +7372,7 @@
                                 "context": "brief"
                             }
                         ],
-                        "rcsb_current_maximum_value": 2145158999.0,
+                        "rcsb_current_maximum_value": 150000000.0,
                         "rcsb_current_minimum_value": 1.0
                     }
                 },
@@ -14037,6 +14033,851 @@
             "minItems": 1,
             "uniqueItems": true
         },
+        "pdbx_vrpt_summary": {
+            "type": "object",
+            "properties": {
+                "RNA_suiteness": {
+                    "type": "number",
+                    "examples": [
+                        0.89
+                    ],
+                    "description": "The MolProbity conformer-match quality parameter for RNA structures.\nLow values are worse. Specific to structures that contain RNA polymers.",
+                    "rcsb_description": [
+                        {
+                            "text": "The MolProbity conformer-match quality parameter for RNA structures.\nLow values are worse. Specific to structures that contain RNA polymers.",
+                            "context": "dictionary"
+                        }
+                    ]
+                },
+                "attempted_validation_steps": {
+                    "type": "string",
+                    "description": "The steps that were attempted by the validation pipeline software. \nA step typically involves running a 3rd party validation tool, for instance \"mogul\"\nEach step will be enumerated in _pdbx_vrpt_software category.",
+                    "rcsb_description": [
+                        {
+                            "text": "The steps that were attempted by the validation pipeline software. \nA step typically involves running a 3rd party validation tool, for instance \"mogul\"\nEach step will be enumerated in _pdbx_vrpt_software category.",
+                            "context": "dictionary"
+                        }
+                    ]
+                },
+                "ligands_for_buster_report": {
+                    "type": "string",
+                    "enum": [
+                        "N",
+                        "Y"
+                    ],
+                    "description": "A flag indicating if there are ligands in the model used for detailed Buster analysis.",
+                    "rcsb_description": [
+                        {
+                            "text": "A flag indicating if there are ligands in the model used for detailed Buster analysis.",
+                            "context": "dictionary"
+                        }
+                    ]
+                },
+                "report_creation_date": {
+                    "type": "string",
+                    "format": "date-time",
+                    "description": "The date, time and time-zone that the validation report  was created. \nThe string will be formatted like yyyy-mm-dd:hh:mm in GMT time.",
+                    "rcsb_description": [
+                        {
+                            "text": "The date, time and time-zone that the validation report  was created. \nThe string will be formatted like yyyy-mm-dd:hh:mm in GMT time.",
+                            "context": "dictionary"
+                        }
+                    ]
+                },
+                "restypes_notchecked_for_bond_angle_geometry": {
+                    "type": "array",
+                    "items": {
+                        "type": "string",
+                        "description": "This is a comma separated list of the residue types whose bond lengths and bond angles have \nnot been checked against \"standard geometry\" using the MolProbity dangle program.\nStandard geometry parameters are taken from Engh and Huber (2001) and Parkinson et al. (1996)",
+                        "rcsb_description": [
+                            {
+                                "text": "This is a comma separated list of the residue types whose bond lengths and bond angles have \nnot been checked against \"standard geometry\" using the MolProbity dangle program.\nStandard geometry parameters are taken from Engh and Huber (2001) and Parkinson et al. (1996)",
+                                "context": "dictionary"
+                            }
+                        ]
+                    },
+                    "uniqueItems": false
+                }
+            },
+            "additionalProperties": false
+        },
+        "pdbx_vrpt_summary_diffraction": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "B_factor_type": {
+                        "type": "string",
+                        "enum": [
+                            "FULL",
+                            "PARTIAL"
+                        ],
+                        "description": "An indicator if isotropic B factors are partial or full values.",
+                        "rcsb_description": [
+                            {
+                                "text": "An indicator if isotropic B factors are partial or full values.",
+                                "context": "dictionary"
+                            }
+                        ]
+                    },
+                    "Babinet_b": {
+                        "type": "number",
+                        "description": "REFMAC scaling parameter as reported in log output line starting 'bulk solvent: scale'.\nX-ray entry specific, obtained in the EDS step from REFMAC calculation.",
+                        "rcsb_description": [
+                            {
+                                "text": "REFMAC scaling parameter as reported in log output line starting 'bulk solvent: scale'.\nX-ray entry specific, obtained in the EDS step from REFMAC calculation.",
+                                "context": "dictionary"
+                            }
+                        ]
+                    },
+                    "Babinet_k": {
+                        "type": "number",
+                        "description": "REFMAC scaling parameter as reported in log output line starting 'bulk solvent: scale'.\nX-ray entry specific, obtained in the EDS step from REFMAC calculation.",
+                        "rcsb_description": [
+                            {
+                                "text": "REFMAC scaling parameter as reported in log output line starting 'bulk solvent: scale'.\nX-ray entry specific, obtained in the EDS step from REFMAC calculation.",
+                                "context": "dictionary"
+                            }
+                        ]
+                    },
+                    "CCP4_version": {
+                        "type": "string",
+                        "description": "The version of CCP4 suite used in the analysis.",
+                        "rcsb_description": [
+                            {
+                                "text": "The version of CCP4 suite used in the analysis.",
+                                "context": "dictionary"
+                            }
+                        ]
+                    },
+                    "DCC_R": {
+                        "type": "number",
+                        "description": "The overall R-factor from a DCC recalculation of an electron density map.\nCurrently value is rounded to 2 decimal places.\nX-ray entry specific, obtained from the DCC program.",
+                        "rcsb_description": [
+                            {
+                                "text": "The overall R-factor from a DCC recalculation of an electron density map.\nCurrently value is rounded to 2 decimal places.\nX-ray entry specific, obtained from the DCC program.",
+                                "context": "dictionary"
+                            }
+                        ]
+                    },
+                    "DCC_Rfree": {
+                        "type": "number",
+                        "description": "Rfree as calculated by DCC.",
+                        "rcsb_description": [
+                            {
+                                "text": "Rfree as calculated by DCC.",
+                                "context": "dictionary"
+                            }
+                        ]
+                    },
+                    "EDS_R": {
+                        "type": "number",
+                        "description": "The overall R factor from the EDS REFMAC calculation (no free set is used in this).\nCurrently value is rounded to 2 decimal places.\nX-ray entry specific, obtained in the eds step from REFMAC calculation.",
+                        "rcsb_description": [
+                            {
+                                "text": "The overall R factor from the EDS REFMAC calculation (no free set is used in this).\nCurrently value is rounded to 2 decimal places.\nX-ray entry specific, obtained in the eds step from REFMAC calculation.",
+                                "context": "dictionary"
+                            }
+                        ]
+                    },
+                    "EDS_R_warning": {
+                        "type": "string",
+                        "description": "Warning message when EDS calculated R vs reported R is higher than a threshold",
+                        "rcsb_description": [
+                            {
+                                "text": "Warning message when EDS calculated R vs reported R is higher than a threshold",
+                                "context": "dictionary"
+                            }
+                        ]
+                    },
+                    "EDS_res_high": {
+                        "type": "number",
+                        "description": "The data high resolution diffraction limit, in Angstroms, found in the input structure factor file.\nX-ray entry specific, obtained in the EDS step.",
+                        "rcsb_units": "angstroms",
+                        "rcsb_description": [
+                            {
+                                "text": "The data high resolution diffraction limit, in Angstroms, found in the input structure factor file.\nX-ray entry specific, obtained in the EDS step.",
+                                "context": "dictionary"
+                            }
+                        ]
+                    },
+                    "EDS_res_low": {
+                        "type": "number",
+                        "description": "The data low resolution diffraction limit, in Angstroms, found in the input structure factor file.\nX-ray entry specific, obtained in the EDS step.",
+                        "rcsb_units": "angstroms",
+                        "rcsb_description": [
+                            {
+                                "text": "The data low resolution diffraction limit, in Angstroms, found in the input structure factor file.\nX-ray entry specific, obtained in the EDS step.",
+                                "context": "dictionary"
+                            }
+                        ]
+                    },
+                    "Fo_Fc_correlation": {
+                        "type": "number",
+                        "description": "Fo,Fc correlation: The difference between the observed structure factors (Fo) and the \ncalculated structure factors (Fc) measures the correlation between the model and the\nexperimental data. \nX-ray entry specific, obtained in the eds step from REFMAC calculation.",
+                        "rcsb_description": [
+                            {
+                                "text": "Fo,Fc correlation: The difference between the observed structure factors (Fo) and the \ncalculated structure factors (Fc) measures the correlation between the model and the\nexperimental data. \nX-ray entry specific, obtained in the eds step from REFMAC calculation.",
+                                "context": "dictionary"
+                            }
+                        ]
+                    },
+                    "I_over_sigma": {
+                        "type": "string",
+                        "description": "Each reflection has an intensity (I) and an uncertainty in measurement \n(sigma(I)), so I/sigma(I) is the signal-to-noise ratio. This\nratio decreases at higher resolution. <I/sigma(I)> is the mean of individual I/sigma(I)\nvalues. Value for outer resolution shell is given in parentheses. In case\nstructure factor amplitudes are deposited, Xtriage estimates the intensities\nfirst and then calculates this metric. When intensities are available in the\ndeposited file, these are converted to amplitudes and then back to intensity\nestimate before calculating the metric.  \nX-ray entry specific, calculated by Phenix Xtriage program.",
+                        "rcsb_description": [
+                            {
+                                "text": "Each reflection has an intensity (I) and an uncertainty in measurement \n(sigma(I)), so I/sigma(I) is the signal-to-noise ratio. This\nratio decreases at higher resolution. <I/sigma(I)> is the mean of individual I/sigma(I)\nvalues. Value for outer resolution shell is given in parentheses. In case\nstructure factor amplitudes are deposited, Xtriage estimates the intensities\nfirst and then calculates this metric. When intensities are available in the\ndeposited file, these are converted to amplitudes and then back to intensity\nestimate before calculating the metric.  \nX-ray entry specific, calculated by Phenix Xtriage program.",
+                                "context": "dictionary"
+                            }
+                        ]
+                    },
+                    "Padilla_Yeates_L2_mean": {
+                        "type": "number",
+                        "description": "Padilla and Yeates twinning parameter <|L**2|>.\nTheoretical values is 0.333 in the untwinned case, and 0.2 in the perfectly twinned case.\nX-ray entry specific, obtained from the Xtriage program.",
+                        "rcsb_description": [
+                            {
+                                "text": "Padilla and Yeates twinning parameter <|L**2|>.\nTheoretical values is 0.333 in the untwinned case, and 0.2 in the perfectly twinned case.\nX-ray entry specific, obtained from the Xtriage program.",
+                                "context": "dictionary"
+                            }
+                        ]
+                    },
+                    "Padilla_Yeates_L_mean": {
+                        "type": "number",
+                        "description": "Padilla and Yeates twinning parameter <|L|>.\nTheoretical values is 0.5 in the untwinned case, and 0.375 in the perfectly twinned case.\nX-ray entry specific, obtained from the Xtriage program.",
+                        "rcsb_description": [
+                            {
+                                "text": "Padilla and Yeates twinning parameter <|L|>.\nTheoretical values is 0.5 in the untwinned case, and 0.375 in the perfectly twinned case.\nX-ray entry specific, obtained from the Xtriage program.",
+                                "context": "dictionary"
+                            }
+                        ]
+                    },
+                    "Q_score": {
+                        "type": "number",
+                        "description": "The overall Q-score of the fit of coordinates to the electron map.\nThe Q-score is defined in Pintilie, GH. et al., Nature Methods, 17, 328-334 (2020)",
+                        "rcsb_description": [
+                            {
+                                "text": "The overall Q-score of the fit of coordinates to the electron map.\nThe Q-score is defined in Pintilie, GH. et al., Nature Methods, 17, 328-334 (2020)",
+                                "context": "dictionary"
+                            }
+                        ]
+                    },
+                    "Wilson_B_aniso": {
+                        "type": "string",
+                        "description": "Result of absolute likelihood based Wilson scaling, \nThe anisotropic B value of the data is determined using a likelihood based approach. \nThe resulting B tensor is reported, the 3 diagonal values are given first, followed\nby the 3 off diagonal values.\nA large spread in (especially the diagonal) values indicates anisotropy. \nX-ray entry specific, calculated by Phenix Xtriage program.",
+                        "rcsb_description": [
+                            {
+                                "text": "Result of absolute likelihood based Wilson scaling, \nThe anisotropic B value of the data is determined using a likelihood based approach. \nThe resulting B tensor is reported, the 3 diagonal values are given first, followed\nby the 3 off diagonal values.\nA large spread in (especially the diagonal) values indicates anisotropy. \nX-ray entry specific, calculated by Phenix Xtriage program.",
+                                "context": "dictionary"
+                            }
+                        ]
+                    },
+                    "Wilson_B_estimate": {
+                        "type": "number",
+                        "description": "An estimate of the overall B-value of the structure, calculated from the diffraction data. \nUnits Angstroms squared.\nIt serves as an indicator of the degree of order in the crystal and the value is usually \nnot hugely different from the average B-value calculated from the model.\nX-ray entry specific, calculated by Phenix Xtriage program.",
+                        "rcsb_units": "angstroms_squared",
+                        "rcsb_description": [
+                            {
+                                "text": "An estimate of the overall B-value of the structure, calculated from the diffraction data. \nUnits Angstroms squared.\nIt serves as an indicator of the degree of order in the crystal and the value is usually \nnot hugely different from the average B-value calculated from the model.\nX-ray entry specific, calculated by Phenix Xtriage program.",
+                                "context": "dictionary"
+                            }
+                        ]
+                    },
+                    "acentric_outliers": {
+                        "type": "integer",
+                        "description": "The number of acentric reflections that Xtriage identifies as outliers on the basis \nof Wilson statistics. Note that if pseudo translational symmetry is present, \na large number of 'outliers' will be present.\nX-ray entry specific, calculated by Phenix Xtriage program.",
+                        "rcsb_description": [
+                            {
+                                "text": "The number of acentric reflections that Xtriage identifies as outliers on the basis \nof Wilson statistics. Note that if pseudo translational symmetry is present, \na large number of 'outliers' will be present.\nX-ray entry specific, calculated by Phenix Xtriage program.",
+                                "context": "dictionary"
+                            }
+                        ]
+                    },
+                    "bulk_solvent_b": {
+                        "type": "number",
+                        "description": "REFMAC scaling parameter as reported in log output file.\nX-ray entry specific, obtained in the EDS step from REFMAC calculation.",
+                        "rcsb_description": [
+                            {
+                                "text": "REFMAC scaling parameter as reported in log output file.\nX-ray entry specific, obtained in the EDS step from REFMAC calculation.",
+                                "context": "dictionary"
+                            }
+                        ]
+                    },
+                    "bulk_solvent_k": {
+                        "type": "number",
+                        "description": "REFMAC reported scaling parameter.\nX-ray entry specific, obtained in the EDS step from REFMAC calculation.",
+                        "rcsb_description": [
+                            {
+                                "text": "REFMAC reported scaling parameter.\nX-ray entry specific, obtained in the EDS step from REFMAC calculation.",
+                                "context": "dictionary"
+                            }
+                        ]
+                    },
+                    "centric_outliers": {
+                        "type": "integer",
+                        "description": "The number of centric reflections that Xtriage identifies as outliers.\nX-ray entry specific, calculated by Phenix Xtriage program.",
+                        "rcsb_description": [
+                            {
+                                "text": "The number of centric reflections that Xtriage identifies as outliers.\nX-ray entry specific, calculated by Phenix Xtriage program.",
+                                "context": "dictionary"
+                            }
+                        ]
+                    },
+                    "data_anisotropy": {
+                        "type": "number",
+                        "description": "The ratio (Bmax - Bmin) / Bmean where Bmax, Bmin and Bmean are computed from the B-values \nassociated with the principal axes of the anisotropic thermal ellipsoid. \nThis ratio is usually less than 0.5; for only 1% of PDB entries it is more than 1.0 (Read et al., 2011).\nX-ray entry specific, obtained from the Xtriage program.",
+                        "rcsb_description": [
+                            {
+                                "text": "The ratio (Bmax - Bmin) / Bmean where Bmax, Bmin and Bmean are computed from the B-values \nassociated with the principal axes of the anisotropic thermal ellipsoid. \nThis ratio is usually less than 0.5; for only 1% of PDB entries it is more than 1.0 (Read et al., 2011).\nX-ray entry specific, obtained from the Xtriage program.",
+                                "context": "dictionary"
+                            }
+                        ]
+                    },
+                    "data_completeness": {
+                        "type": "number",
+                        "description": "The percent completeness of diffraction data.",
+                        "rcsb_description": [
+                            {
+                                "text": "The percent completeness of diffraction data.",
+                                "context": "dictionary"
+                            }
+                        ]
+                    },
+                    "density_fitness_version": {
+                        "type": "string",
+                        "description": "The version of density-fitness suite programs used in the analysis.",
+                        "rcsb_description": [
+                            {
+                                "text": "The version of density-fitness suite programs used in the analysis.",
+                                "context": "dictionary"
+                            }
+                        ]
+                    },
+                    "exp_method": {
+                        "type": "string",
+                        "description": "Experimental method for statistics",
+                        "rcsb_description": [
+                            {
+                                "text": "Experimental method for statistics",
+                                "context": "dictionary"
+                            }
+                        ]
+                    },
+                    "num_miller_indices": {
+                        "type": "integer",
+                        "description": "The number of Miller Indices reported by the Xtriage program. This should be the same as the\nnumber of _refln in the input structure factor file.\nX-ray entry specific, calculated by Phenix Xtriage program.",
+                        "rcsb_description": [
+                            {
+                                "text": "The number of Miller Indices reported by the Xtriage program. This should be the same as the\nnumber of _refln in the input structure factor file.\nX-ray entry specific, calculated by Phenix Xtriage program.",
+                                "context": "dictionary"
+                            }
+                        ]
+                    },
+                    "number_reflns_R_free": {
+                        "type": "integer",
+                        "description": "The number of reflections in the free set as defined in the input structure factor file supplied to the validation pipeline. \nX-ray entry specific, obtained from the DCC program.",
+                        "rcsb_description": [
+                            {
+                                "text": "The number of reflections in the free set as defined in the input structure factor file supplied to the validation pipeline. \nX-ray entry specific, obtained from the DCC program.",
+                                "context": "dictionary"
+                            }
+                        ]
+                    },
+                    "percent_RSRZ_outliers": {
+                        "type": "number",
+                        "description": "The percent of RSRZ outliers.",
+                        "rcsb_description": [
+                            {
+                                "text": "The percent of RSRZ outliers.",
+                                "context": "dictionary"
+                            }
+                        ]
+                    },
+                    "percent_free_reflections": {
+                        "type": "number",
+                        "description": "A percentage, Normally percent proportion of the total number. Between 0% and 100%.",
+                        "rcsb_description": [
+                            {
+                                "text": "A percentage, Normally percent proportion of the total number. Between 0% and 100%.",
+                                "context": "dictionary"
+                            }
+                        ]
+                    },
+                    "servalcat_version": {
+                        "type": "string",
+                        "description": "The version of Servalcat program used in the analysis.",
+                        "rcsb_description": [
+                            {
+                                "text": "The version of Servalcat program used in the analysis.",
+                                "context": "dictionary"
+                            }
+                        ]
+                    },
+                    "trans_NCS_details": {
+                        "type": "string",
+                        "examples": [
+                            "The largest off-origin peak in the Patterson function is 8.82% of the height of the origin peak. No significant pseudotranslation is detected."
+                        ],
+                        "description": "A sentence giving the result of Xtriage's analysis on translational NCS.\nX-ray entry specific, obtained from the Xtriage program.",
+                        "rcsb_description": [
+                            {
+                                "text": "A sentence giving the result of Xtriage's analysis on translational NCS.\nX-ray entry specific, obtained from the Xtriage program.",
+                                "context": "dictionary"
+                            }
+                        ]
+                    },
+                    "twin_fraction": {
+                        "type": "string",
+                        "examples": [
+                            "h,h-k,h-l:0.477;-h,-h+k,-l:0.020;-h,-k,-h+l:0.017"
+                        ],
+                        "description": "Estimated twinning fraction for operators as identified by Xtriage. A semicolon separated\nlist of operators with fractions is givens \nX-ray entry specific, obtained from the Xtriage program.",
+                        "rcsb_description": [
+                            {
+                                "text": "Estimated twinning fraction for operators as identified by Xtriage. A semicolon separated\nlist of operators with fractions is givens \nX-ray entry specific, obtained from the Xtriage program.",
+                                "context": "dictionary"
+                            }
+                        ]
+                    }
+                },
+                "additionalProperties": false
+            },
+            "minItems": 1,
+            "uniqueItems": true
+        },
+        "pdbx_vrpt_summary_em": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "Q_score": {
+                        "type": "number",
+                        "description": "The overall Q-score of the fit of coordinates to the electron map.\nThe Q-score is defined in Pintilie, GH. et al., Nature Methods, 17, 328-334 (2020)",
+                        "rcsb_description": [
+                            {
+                                "text": "The overall Q-score of the fit of coordinates to the electron map.\nThe Q-score is defined in Pintilie, GH. et al., Nature Methods, 17, 328-334 (2020)",
+                                "context": "dictionary"
+                            }
+                        ]
+                    },
+                    "atom_inclusion_all_atoms": {
+                        "type": "number",
+                        "description": "The proportion of all non hydrogen atoms within density.",
+                        "rcsb_description": [
+                            {
+                                "text": "The proportion of all non hydrogen atoms within density.",
+                                "context": "dictionary"
+                            }
+                        ]
+                    },
+                    "atom_inclusion_backbone": {
+                        "type": "number",
+                        "description": "The proportion of backbone atoms within density.",
+                        "rcsb_description": [
+                            {
+                                "text": "The proportion of backbone atoms within density.",
+                                "context": "dictionary"
+                            }
+                        ]
+                    },
+                    "author_provided_fsc_resolution_by_cutoff_halfbit": {
+                        "type": "number",
+                        "description": "The resolution from the intersection of the author provided fsc and the indicator curve halfbit.",
+                        "rcsb_description": [
+                            {
+                                "text": "The resolution from the intersection of the author provided fsc and the indicator curve halfbit.",
+                                "context": "dictionary"
+                            }
+                        ]
+                    },
+                    "author_provided_fsc_resolution_by_cutoff_onebit": {
+                        "type": "number",
+                        "description": "The resolution from the intersection of the author provided fsc and the indicator curve onebit.",
+                        "rcsb_description": [
+                            {
+                                "text": "The resolution from the intersection of the author provided fsc and the indicator curve onebit.",
+                                "context": "dictionary"
+                            }
+                        ]
+                    },
+                    "author_provided_fsc_resolution_by_cutoff_pt_143": {
+                        "type": "number",
+                        "description": "The resolution from the intersection of the author provided fsc and the indicator curve 0.143.",
+                        "rcsb_description": [
+                            {
+                                "text": "The resolution from the intersection of the author provided fsc and the indicator curve 0.143.",
+                                "context": "dictionary"
+                            }
+                        ]
+                    },
+                    "author_provided_fsc_resolution_by_cutoff_pt_333": {
+                        "type": "number",
+                        "description": "The resolution from the intersection of the author provided fsc and the indicator curve 0.333.",
+                        "rcsb_description": [
+                            {
+                                "text": "The resolution from the intersection of the author provided fsc and the indicator curve 0.333.",
+                                "context": "dictionary"
+                            }
+                        ]
+                    },
+                    "author_provided_fsc_resolution_by_cutoff_pt_5": {
+                        "type": "number",
+                        "description": "The resolution from the intersection of the author provided fsc and the indicator curve 0.5.",
+                        "rcsb_description": [
+                            {
+                                "text": "The resolution from the intersection of the author provided fsc and the indicator curve 0.5.",
+                                "context": "dictionary"
+                            }
+                        ]
+                    },
+                    "author_provided_fsc_resolution_by_cutoff_threesigma": {
+                        "type": "number",
+                        "description": "The resolution from the intersection of the author provided fsc and the indicator curve threesigma.",
+                        "rcsb_description": [
+                            {
+                                "text": "The resolution from the intersection of the author provided fsc and the indicator curve threesigma.",
+                                "context": "dictionary"
+                            }
+                        ]
+                    },
+                    "calculated_fsc_resolution_by_cutoff_halfbit": {
+                        "type": "number",
+                        "description": "The resolution from the intersection of the fsc curve generated by from the provided halfmaps and the indicator curve halfbit.",
+                        "rcsb_description": [
+                            {
+                                "text": "The resolution from the intersection of the fsc curve generated by from the provided halfmaps and the indicator curve halfbit.",
+                                "context": "dictionary"
+                            }
+                        ]
+                    },
+                    "calculated_fsc_resolution_by_cutoff_onebit": {
+                        "type": "number",
+                        "description": "The resolution from the intersection of the fsc curve generated by from the provided halfmaps and the indicator curve onebit.",
+                        "rcsb_description": [
+                            {
+                                "text": "The resolution from the intersection of the fsc curve generated by from the provided halfmaps and the indicator curve onebit.",
+                                "context": "dictionary"
+                            }
+                        ]
+                    },
+                    "calculated_fsc_resolution_by_cutoff_pt_143": {
+                        "type": "number",
+                        "description": "The resolution from the intersection of the fsc curve generated by from the provided halfmaps and the indicator curve 0.143.",
+                        "rcsb_description": [
+                            {
+                                "text": "The resolution from the intersection of the fsc curve generated by from the provided halfmaps and the indicator curve 0.143.",
+                                "context": "dictionary"
+                            }
+                        ]
+                    },
+                    "calculated_fsc_resolution_by_cutoff_pt_333": {
+                        "type": "number",
+                        "description": "The resolution from the intersection of the fsc curve generated by from the provided halfmaps and the indicator curve 0.333.",
+                        "rcsb_description": [
+                            {
+                                "text": "The resolution from the intersection of the fsc curve generated by from the provided halfmaps and the indicator curve 0.333.",
+                                "context": "dictionary"
+                            }
+                        ]
+                    },
+                    "calculated_fsc_resolution_by_cutoff_pt_5": {
+                        "type": "number",
+                        "description": "The resolution from the intersection of the fsc curve generated by from the provided halfmaps and the indicator curve 0.5.",
+                        "rcsb_description": [
+                            {
+                                "text": "The resolution from the intersection of the fsc curve generated by from the provided halfmaps and the indicator curve 0.5.",
+                                "context": "dictionary"
+                            }
+                        ]
+                    },
+                    "calculated_fsc_resolution_by_cutoff_threesigma": {
+                        "type": "number",
+                        "description": "The resolution from the intersection of the fsc curve generated by from the provided halfmaps and the indicator curve threesigma.",
+                        "rcsb_description": [
+                            {
+                                "text": "The resolution from the intersection of the fsc curve generated by from the provided halfmaps and the indicator curve threesigma.",
+                                "context": "dictionary"
+                            }
+                        ]
+                    },
+                    "contour_level_primary_map": {
+                        "type": "number",
+                        "description": "The recommended contour level for the primary map of this deposition.",
+                        "rcsb_description": [
+                            {
+                                "text": "The recommended contour level for the primary map of this deposition.",
+                                "context": "dictionary"
+                            }
+                        ]
+                    },
+                    "exp_method": {
+                        "type": "string",
+                        "description": "Experimental method for statistics",
+                        "rcsb_description": [
+                            {
+                                "text": "Experimental method for statistics",
+                                "context": "dictionary"
+                            }
+                        ]
+                    }
+                },
+                "additionalProperties": false
+            },
+            "minItems": 1,
+            "uniqueItems": true
+        },
+        "pdbx_vrpt_summary_geometry": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "angles_RMSZ": {
+                        "type": "number",
+                        "description": "The overall root mean square of the Z-score for deviations of bond angles in comparison to \n\"standard geometry\" made using the MolProbity dangle program.\nStandard geometry parameters are taken from Engh and Huber (2001) and Parkinson et al. (1996).\nThis value is for all chains in the structure.",
+                        "rcsb_description": [
+                            {
+                                "text": "The overall root mean square of the Z-score for deviations of bond angles in comparison to \n\"standard geometry\" made using the MolProbity dangle program.\nStandard geometry parameters are taken from Engh and Huber (2001) and Parkinson et al. (1996).\nThis value is for all chains in the structure.",
+                                "context": "dictionary"
+                            }
+                        ]
+                    },
+                    "bonds_RMSZ": {
+                        "type": "number",
+                        "description": "The overall root mean square of the Z-score for deviations of bond lengths in comparison to \n\"standard geometry\" made using the MolProbity dangle program.\nStandard geometry parameters are taken from Engh and Huber (2001) and Parkinson et al. (1996).\nThis value is for all chains in the structure.",
+                        "rcsb_description": [
+                            {
+                                "text": "The overall root mean square of the Z-score for deviations of bond lengths in comparison to \n\"standard geometry\" made using the MolProbity dangle program.\nStandard geometry parameters are taken from Engh and Huber (2001) and Parkinson et al. (1996).\nThis value is for all chains in the structure.",
+                                "context": "dictionary"
+                            }
+                        ]
+                    },
+                    "clashscore": {
+                        "type": "number",
+                        "description": "This score is derived from the number of pairs of atoms in the PDB_model_num that are unusually close to each other. \nIt is calculated by the MolProbity pdbx_vrpt_software and expressed as the number or such clashes per thousand atoms.\nFor structures determined by NMR the clashscore value here will only consider label_atom_id pairs in the \nwell-defined (core) residues from ensemble analysis.",
+                        "rcsb_description": [
+                            {
+                                "text": "This score is derived from the number of pairs of atoms in the PDB_model_num that are unusually close to each other. \nIt is calculated by the MolProbity pdbx_vrpt_software and expressed as the number or such clashes per thousand atoms.\nFor structures determined by NMR the clashscore value here will only consider label_atom_id pairs in the \nwell-defined (core) residues from ensemble analysis.",
+                                "context": "dictionary"
+                            }
+                        ]
+                    },
+                    "clashscore_full_length": {
+                        "type": "number",
+                        "description": "Only given for structures determined by NMR. The MolProbity pdbx_vrpt_instance_clashes score for all label_atom_id pairs.",
+                        "rcsb_description": [
+                            {
+                                "text": "Only given for structures determined by NMR. The MolProbity pdbx_vrpt_instance_clashes score for all label_atom_id pairs.",
+                                "context": "dictionary"
+                            }
+                        ]
+                    },
+                    "num_H_reduce": {
+                        "type": "integer",
+                        "description": "This is the number of hydrogen atoms added and optimized by the MolProbity reduce pdbx_vrpt_software as part of the\nall-atom clashscore.",
+                        "rcsb_description": [
+                            {
+                                "text": "This is the number of hydrogen atoms added and optimized by the MolProbity reduce pdbx_vrpt_software as part of the\nall-atom clashscore.",
+                                "context": "dictionary"
+                            }
+                        ]
+                    },
+                    "num_angles_RMSZ": {
+                        "type": "integer",
+                        "description": "The number of bond angles compared to \"standard geometry\" made using the MolProbity dangle program.\nStandard geometry parameters are taken from Engh and Huber (2001) and Parkinson et al. (1996).\nThis value is for all chains in the structure.",
+                        "rcsb_description": [
+                            {
+                                "text": "The number of bond angles compared to \"standard geometry\" made using the MolProbity dangle program.\nStandard geometry parameters are taken from Engh and Huber (2001) and Parkinson et al. (1996).\nThis value is for all chains in the structure.",
+                                "context": "dictionary"
+                            }
+                        ]
+                    },
+                    "num_bonds_RMSZ": {
+                        "type": "integer",
+                        "description": "The number of bond lengths compared to \"standard geometry\" made using the MolProbity dangle program.\nStandard geometry parameters are taken from Engh and Huber (2001) and Parkinson et al. (1996).\nThis value is for all chains in the structure.",
+                        "rcsb_description": [
+                            {
+                                "text": "The number of bond lengths compared to \"standard geometry\" made using the MolProbity dangle program.\nStandard geometry parameters are taken from Engh and Huber (2001) and Parkinson et al. (1996).\nThis value is for all chains in the structure.",
+                                "context": "dictionary"
+                            }
+                        ]
+                    },
+                    "percent_ramachandran_outliers": {
+                        "type": "number",
+                        "description": "The percentage of residues with Ramachandran outliers.",
+                        "rcsb_description": [
+                            {
+                                "text": "The percentage of residues with Ramachandran outliers.",
+                                "context": "dictionary"
+                            }
+                        ]
+                    },
+                    "percent_ramachandran_outliers_full_length": {
+                        "type": "number",
+                        "description": "Only given for structures determined by NMR. The MolProbity Ramachandran outlier score\nfor all atoms in the structure rather than just the well-defined (core) residues.",
+                        "rcsb_description": [
+                            {
+                                "text": "Only given for structures determined by NMR. The MolProbity Ramachandran outlier score\nfor all atoms in the structure rather than just the well-defined (core) residues.",
+                                "context": "dictionary"
+                            }
+                        ]
+                    },
+                    "percent_rotamer_outliers": {
+                        "type": "number",
+                        "description": "The MolProbity sidechain outlier score (a percentage).\nProtein sidechains mostly adopt certain (combinations of) preferred torsion angle values \n(called rotamers or rotameric conformers), much like their backbone torsion angles \n(as assessed in the Ramachandran analysis). MolProbity considers the sidechain conformation \nof a residue to be an outlier if its set of torsion angles is not similar to any preferred \ncombination. The sidechain outlier score is calculated as the percentage of residues \nwith an unusual sidechain conformation with respect to the total number of residues for \nwhich the assessment is available.\nExample: percent-rota-outliers=\"2.44\".\nSpecific to structure that contain protein chains and have sidechains modelled.\nFor NMR structures only the  well-defined (core) residues from ensemble analysis will be considered.\nThe percentage of residues with rotamer outliers.",
+                        "rcsb_description": [
+                            {
+                                "text": "The MolProbity sidechain outlier score (a percentage).\nProtein sidechains mostly adopt certain (combinations of) preferred torsion angle values \n(called rotamers or rotameric conformers), much like their backbone torsion angles \n(as assessed in the Ramachandran analysis). MolProbity considers the sidechain conformation \nof a residue to be an outlier if its set of torsion angles is not similar to any preferred \ncombination. The sidechain outlier score is calculated as the percentage of residues \nwith an unusual sidechain conformation with respect to the total number of residues for \nwhich the assessment is available.\nExample: percent-rota-outliers=\"2.44\".\nSpecific to structure that contain protein chains and have sidechains modelled.\nFor NMR structures only the  well-defined (core) residues from ensemble analysis will be considered.\nThe percentage of residues with rotamer outliers.",
+                                "context": "dictionary"
+                            }
+                        ]
+                    },
+                    "percent_rotamer_outliers_full_length": {
+                        "type": "number",
+                        "description": "Only given for structures determined by NMR. The MolProbity sidechain outlier score\nfor all atoms in the structure rather than just the well-defined (core) residues.",
+                        "rcsb_description": [
+                            {
+                                "text": "Only given for structures determined by NMR. The MolProbity sidechain outlier score\nfor all atoms in the structure rather than just the well-defined (core) residues.",
+                                "context": "dictionary"
+                            }
+                        ]
+                    }
+                },
+                "additionalProperties": false
+            },
+            "minItems": 1,
+            "uniqueItems": true
+        },
+        "pdbx_vrpt_summary_nmr": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "chemical_shift_completeness": {
+                        "type": "number",
+                        "description": "Overall completeness of the chemical shift assignments for the well-defined \nregions of the structure.",
+                        "rcsb_description": [
+                            {
+                                "text": "Overall completeness of the chemical shift assignments for the well-defined \nregions of the structure.",
+                                "context": "dictionary"
+                            }
+                        ]
+                    },
+                    "chemical_shift_completeness_full_length": {
+                        "type": "number",
+                        "description": "Overall completeness of the chemical shift assignments for the full \nmacromolecule or complex as suggested by the molecular description of an entry\n(whether some portion of it is modelled or not).",
+                        "rcsb_description": [
+                            {
+                                "text": "Overall completeness of the chemical shift assignments for the full \nmacromolecule or complex as suggested by the molecular description of an entry\n(whether some portion of it is modelled or not).",
+                                "context": "dictionary"
+                            }
+                        ]
+                    },
+                    "cyrange_error": {
+                        "type": "string",
+                        "description": "Diagnostic message from the wrapper of Cyrange software which identifies the \nwell-defined cores (domains) of NMR protein structures.",
+                        "rcsb_description": [
+                            {
+                                "text": "Diagnostic message from the wrapper of Cyrange software which identifies the \nwell-defined cores (domains) of NMR protein structures.",
+                                "context": "dictionary"
+                            }
+                        ]
+                    },
+                    "cyrange_number_of_domains": {
+                        "type": "integer",
+                        "description": "Total number of well-defined cores (domains) identified by Cyrange",
+                        "rcsb_description": [
+                            {
+                                "text": "Total number of well-defined cores (domains) identified by Cyrange",
+                                "context": "dictionary"
+                            }
+                        ]
+                    },
+                    "exp_method": {
+                        "type": "string",
+                        "description": "Experimental method for statistics",
+                        "rcsb_description": [
+                            {
+                                "text": "Experimental method for statistics",
+                                "context": "dictionary"
+                            }
+                        ]
+                    },
+                    "medoid_model": {
+                        "type": "integer",
+                        "description": "For each Cyrange well-defined core (\"cyrange_domain\") the id of the PDB_model_num which is most \nsimilar to other models as measured by pairwise RMSDs over the domain. \nFor the whole entry (\"Entry\"), the medoid PDB_model_num of the largest core is taken as an overall\nrepresentative of the structure.",
+                        "rcsb_description": [
+                            {
+                                "text": "For each Cyrange well-defined core (\"cyrange_domain\") the id of the PDB_model_num which is most \nsimilar to other models as measured by pairwise RMSDs over the domain. \nFor the whole entry (\"Entry\"), the medoid PDB_model_num of the largest core is taken as an overall\nrepresentative of the structure.",
+                                "context": "dictionary"
+                            }
+                        ]
+                    },
+                    "nmr_models_consistency_flag": {
+                        "type": "string",
+                        "description": "A flag indicating if all models in the NMR ensemble contain the exact \nsame atoms (\"True\") or if the models differ in this respect (\"False\").",
+                        "rcsb_description": [
+                            {
+                                "text": "A flag indicating if all models in the NMR ensemble contain the exact \nsame atoms (\"True\") or if the models differ in this respect (\"False\").",
+                                "context": "dictionary"
+                            }
+                        ]
+                    },
+                    "nmrclust_error": {
+                        "type": "string",
+                        "description": "Diagnostic message from the wrapper of NMRClust software which clusters NMR models.",
+                        "rcsb_description": [
+                            {
+                                "text": "Diagnostic message from the wrapper of NMRClust software which clusters NMR models.",
+                                "context": "dictionary"
+                            }
+                        ]
+                    },
+                    "nmrclust_number_of_clusters": {
+                        "type": "integer",
+                        "description": "Total number of clusters in the NMR ensemble identified by NMRClust.",
+                        "rcsb_description": [
+                            {
+                                "text": "Total number of clusters in the NMR ensemble identified by NMRClust.",
+                                "context": "dictionary"
+                            }
+                        ]
+                    },
+                    "nmrclust_number_of_models": {
+                        "type": "integer",
+                        "description": "Number of models analysed by NMRClust - should in almost all cases be the\nsame as the number of models in the NMR ensemble.",
+                        "rcsb_description": [
+                            {
+                                "text": "Number of models analysed by NMRClust - should in almost all cases be the\nsame as the number of models in the NMR ensemble.",
+                                "context": "dictionary"
+                            }
+                        ]
+                    },
+                    "nmrclust_number_of_outliers": {
+                        "type": "integer",
+                        "description": "Number of models that do not belong to any cluster as deemed by NMRClust.",
+                        "rcsb_description": [
+                            {
+                                "text": "Number of models that do not belong to any cluster as deemed by NMRClust.",
+                                "context": "dictionary"
+                            }
+                        ]
+                    },
+                    "nmrclust_representative_model": {
+                        "type": "integer",
+                        "description": "Overall representative PDB_model_num of the NMR ensemble as identified by NMRClust.",
+                        "rcsb_description": [
+                            {
+                                "text": "Overall representative PDB_model_num of the NMR ensemble as identified by NMRClust.",
+                                "context": "dictionary"
+                            }
+                        ]
+                    }
+                },
+                "additionalProperties": false
+            },
+            "minItems": 1,
+            "uniqueItems": true
+        },
         "rcsb_accession_info": {
             "type": "object",
             "properties": {
@@ -14067,7 +14908,7 @@
                             "priority_order": 20
                         }
                     ],
-                    "rcsb_current_maximum_value": 1730073600000.0,
+                    "rcsb_current_maximum_value": 1736208000000.0,
                     "rcsb_current_minimum_value": 82339200000.0
                 },
                 "has_released_experimental_data": {
@@ -14129,7 +14970,7 @@
                             "priority_order": 25
                         }
                     ],
-                    "rcsb_current_maximum_value": 1730851200000.0,
+                    "rcsb_current_maximum_value": 1736899200000.0,
                     "rcsb_current_minimum_value": 201312000000.0
                 },
                 "major_revision": {
@@ -14179,8 +15020,8 @@
                             "priority_order": 30
                         }
                     ],
-                    "rcsb_current_maximum_value": 1730851200000.0,
-                    "rcsb_current_minimum_value": 996710400000.0
+                    "rcsb_current_maximum_value": 1736899200000.0,
+                    "rcsb_current_minimum_value": 1310515200000.0
                 },
                 "status_code": {
                     "type": "string",
@@ -14926,7 +15767,7 @@
                             "priority_order": 60
                         }
                     ],
-                    "rcsb_current_maximum_value": 81798.0,
+                    "rcsb_current_maximum_value": 97627.0,
                     "rcsb_current_minimum_value": 0.0
                 },
                 "disulfide_bond_count": {
@@ -20076,7 +20917,7 @@
                                         23000.0
                                     ],
                                     "rcsb_current_minimum_value": 0.004000000189989805,
-                                    "rcsb_current_maximum_value": 3000000.0
+                                    "rcsb_current_maximum_value": 50000000.0
                                 }
                             ]
                         },
@@ -20158,13 +20999,125 @@
                                         47.2
                                     ],
                                     "rcsb_current_minimum_value": -102.05674743652344,
-                                    "rcsb_current_maximum_value": 90.93575286865234
+                                    "rcsb_current_maximum_value": 1683.699951171875
                                 }
                             ]
                         }
                     ]
                 }
             ]
+        },
+        "pdbx_vrpt_summary_entity_fit_to_map": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "PDB_model_num": {
+                        "type": "integer",
+                        "description": "The unique model number from _atom_site.pdbx_PDB_model_num.",
+                        "rcsb_description": [
+                            {
+                                "text": "The unique model number from _atom_site.pdbx_PDB_model_num.",
+                                "context": "dictionary"
+                            }
+                        ]
+                    },
+                    "Q_score": {
+                        "type": "number",
+                        "description": "The calculated average Q-score.",
+                        "rcsb_description": [
+                            {
+                                "text": "The calculated average Q-score.",
+                                "context": "dictionary"
+                            }
+                        ]
+                    },
+                    "average_residue_inclusion": {
+                        "type": "number",
+                        "description": "The average of the residue inclusions for all residues in this instance",
+                        "rcsb_description": [
+                            {
+                                "text": "The average of the residue inclusions for all residues in this instance",
+                                "context": "dictionary"
+                            }
+                        ]
+                    }
+                },
+                "additionalProperties": false
+            },
+            "minItems": 1,
+            "uniqueItems": true
+        },
+        "pdbx_vrpt_summary_entity_geometry": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "PDB_model_num": {
+                        "type": "integer",
+                        "description": "The unique model number from _atom_site.pdbx_PDB_model_num.",
+                        "rcsb_description": [
+                            {
+                                "text": "The unique model number from _atom_site.pdbx_PDB_model_num.",
+                                "context": "dictionary"
+                            }
+                        ]
+                    },
+                    "angles_RMSZ": {
+                        "type": "number",
+                        "description": "The overall root mean square of the Z-score for deviations of bond angles in comparison to \n\"standard geometry\" made using the MolProbity dangle program.\nStandard geometry parameters are taken from Engh and Huber (2001) and Parkinson et al. (1996).",
+                        "rcsb_description": [
+                            {
+                                "text": "The overall root mean square of the Z-score for deviations of bond angles in comparison to \n\"standard geometry\" made using the MolProbity dangle program.\nStandard geometry parameters are taken from Engh and Huber (2001) and Parkinson et al. (1996).",
+                                "context": "dictionary"
+                            }
+                        ]
+                    },
+                    "average_residue_inclusion": {
+                        "type": "number",
+                        "description": "The average of the residue inclusions for all residues in this instance",
+                        "rcsb_description": [
+                            {
+                                "text": "The average of the residue inclusions for all residues in this instance",
+                                "context": "dictionary"
+                            }
+                        ]
+                    },
+                    "bonds_RMSZ": {
+                        "type": "number",
+                        "description": "The overall root mean square of the Z-score for deviations of bond lengths in comparison to \n\"standard geometry\" made using the MolProbity dangle program.\nStandard geometry parameters are taken from Engh and Huber (2001) and Parkinson et al. (1996).",
+                        "rcsb_description": [
+                            {
+                                "text": "The overall root mean square of the Z-score for deviations of bond lengths in comparison to \n\"standard geometry\" made using the MolProbity dangle program.\nStandard geometry parameters are taken from Engh and Huber (2001) and Parkinson et al. (1996).",
+                                "context": "dictionary"
+                            }
+                        ]
+                    },
+                    "num_angles_RMSZ": {
+                        "type": "integer",
+                        "description": "The number of bond angles compared to \"standard geometry\" made using the MolProbity dangle program.\nStandard geometry parameters are taken from Engh and Huber (2001) and Parkinson et al. (1996).",
+                        "rcsb_description": [
+                            {
+                                "text": "The number of bond angles compared to \"standard geometry\" made using the MolProbity dangle program.\nStandard geometry parameters are taken from Engh and Huber (2001) and Parkinson et al. (1996).",
+                                "context": "dictionary"
+                            }
+                        ]
+                    },
+                    "num_bonds_RMSZ": {
+                        "type": "integer",
+                        "description": "The number of bond lengths compared to \"standard geometry\" made using the MolProbity dangle program.\nStandard geometry parameters are taken from Engh and Huber (2001) and Parkinson et al. (1996).",
+                        "rcsb_description": [
+                            {
+                                "text": "The number of bond lengths compared to \"standard geometry\" made using the MolProbity dangle program.\nStandard geometry parameters are taken from Engh and Huber (2001) and Parkinson et al. (1996).",
+                                "context": "dictionary"
+                            }
+                        ]
+                    }
+                },
+                "additionalProperties": false
+            },
+            "minItems": 1,
+            "uniqueItems": true
         },
         "rcsb_polymer_entity_instance_container_identifiers": {
             "type": "object",
@@ -20752,12 +21705,17 @@
                         "type": "string",
                         "enum": [
                             "ANGLE_OUTLIER",
+                            "ANGLE_OUTLIERS",
+                            "AVERAGE_OCCUPANCY",
                             "BEND",
                             "BINDING_SITE",
                             "BOND_OUTLIER",
+                            "BOND_OUTLIERS",
                             "C-MANNOSYLATION_SITE",
                             "CATH",
+                            "CHIRAL_OUTLIERS",
                             "CIS-PEPTIDE",
+                            "CLASHES",
                             "ECOD",
                             "HELIX_P",
                             "HELX_LH_PP_P",
@@ -20782,12 +21740,23 @@
                             "MA_QA_METRIC_LOCAL_TYPE_ZSCORE",
                             "MEMBRANE_SEGMENT",
                             "MOGUL_ANGLE_OUTLIER",
+                            "MOGUL_ANGLE_OUTLIERS",
                             "MOGUL_BOND_OUTLIER",
+                            "MOGUL_BOND_OUTLIERS",
+                            "MOGUL_RING_OUTLIERS",
+                            "MOGUL_TORSION_OUTLIERS",
                             "N-GLYCOSYLATION_SITE",
+                            "NATOMS_EDS",
                             "O-GLYCOSYLATION_SITE",
+                            "OWAB",
+                            "PLANE_OUTLIERS",
+                            "Q_SCORE",
                             "RAMACHANDRAN_OUTLIER",
                             "ROTAMER_OUTLIER",
+                            "RSCC",
                             "RSCC_OUTLIER",
+                            "RSR",
+                            "RSRZ",
                             "RSRZ_OUTLIER",
                             "S-GLYCOSYLATION_SITE",
                             "SABDAB_ANTIBODY_HEAVY_CHAIN_SUBCLASS",
@@ -20800,6 +21769,7 @@
                             "SHEET",
                             "STEREO_OUTLIER",
                             "STRN",
+                            "SYMM_CLASHES",
                             "TURN_TY1_P",
                             "UNASSIGNED_SEC_STRUCT",
                             "UNOBSERVED_ATOM_XYZ",
@@ -20820,6 +21790,16 @@
                                 "name": "Molprobity bond angle outlier"
                             },
                             {
+                                "value": "ANGLE_OUTLIERS",
+                                "detail": "Number of atoms with angle outliers",
+                                "name": "ANGLE_OUTLIERS"
+                            },
+                            {
+                                "value": "AVERAGE_OCCUPANCY",
+                                "detail": "The average heavy atom occupancy for coordinate records for the residue",
+                                "name": "AVERAGE_OCCUPANCY"
+                            },
+                            {
                                 "value": "BEND",
                                 "detail": "Bend - region with high backbone curvature without specific hydrogen bonding",
                                 "name": "Bend - region with high backbone curvature without specific hydrogen bonding"
@@ -20835,6 +21815,11 @@
                                 "name": "Molprobity bond distance outlier"
                             },
                             {
+                                "value": "BOND_OUTLIERS",
+                                "detail": "Number of atoms with bond outliers",
+                                "name": "BOND_OUTLIERS"
+                            },
+                            {
                                 "value": "C-MANNOSYLATION_SITE",
                                 "detail": "Mannose glycan binding to the first tryptophan (W) residue in the sequence motif WXXW  (where X is any amino acid).",
                                 "name": "C-Mannosylation Site"
@@ -20845,9 +21830,19 @@
                                 "name": "CATH"
                             },
                             {
+                                "value": "CHIRAL_OUTLIERS",
+                                "detail": "Number of chiral outliers",
+                                "name": "CHIRAL_OUTLIERS"
+                            },
+                            {
                                 "value": "CIS-PEPTIDE",
                                 "detail": "Peptide linkages with CIS configurations",
                                 "name": "CIS Peptide linkages"
+                            },
+                            {
+                                "value": "CLASHES",
+                                "detail": "Number of atoms a with clashes",
+                                "name": "CLASHES"
                             },
                             {
                                 "value": "ECOD",
@@ -20970,9 +21965,29 @@
                                 "name": "Mogul bond angle outlier"
                             },
                             {
+                                "value": "MOGUL_ANGLE_OUTLIERS",
+                                "detail": "Number of angle outliers as reported by MOGUL",
+                                "name": "MOGUL_ANGLE_OUTLIERS"
+                            },
+                            {
                                 "value": "MOGUL_BOND_OUTLIER",
                                 "detail": "Mogul bond distance outlier",
                                 "name": "Mogul bond distance outlier"
+                            },
+                            {
+                                "value": "MOGUL_BOND_OUTLIERS",
+                                "detail": "Number of bond outliers as reported by MOGUL",
+                                "name": "MOGUL_BOND_OUTLIERS"
+                            },
+                            {
+                                "value": "MOGUL_RING_OUTLIERS",
+                                "detail": "Number of atoms with ring outliers as reported by MOGUL",
+                                "name": "MOGUL_RING_OUTLIERS"
+                            },
+                            {
+                                "value": "MOGUL_TORSION_OUTLIERS",
+                                "detail": "Number of torsion angle outliers as reported by MOGUL",
+                                "name": "MOGUL_TORSION_OUTLIERS"
                             },
                             {
                                 "value": "N-GLYCOSYLATION_SITE",
@@ -20980,9 +21995,29 @@
                                 "name": "N-Glycosylation Site"
                             },
                             {
+                                "value": "NATOMS_EDS",
+                                "detail": "Number of atoms in the residue returned by the EDS software",
+                                "name": "NATOMS_EDS"
+                            },
+                            {
                                 "value": "O-GLYCOSYLATION_SITE",
                                 "detail": "Glycan binding to the oxygen atom of serine (Ser) or threonine (Thr) residues",
                                 "name": "O-Glycosylation Site"
+                            },
+                            {
+                                "value": "OWAB",
+                                "detail": "Occupancy-weighted Average B value",
+                                "name": "OWAB"
+                            },
+                            {
+                                "value": "PLANE_OUTLIERS",
+                                "detail": "Number of planar outliers",
+                                "name": "PLANE_OUTLIERS"
+                            },
+                            {
+                                "value": "Q_SCORE",
+                                "detail": "Q_score",
+                                "name": "Q_SCORE"
                             },
                             {
                                 "value": "RAMACHANDRAN_OUTLIER",
@@ -20995,9 +22030,24 @@
                                 "name": "Molprobity rotamer outlier"
                             },
                             {
+                                "value": "RSCC",
+                                "detail": "Real space correlation coefficient",
+                                "name": "RSCC"
+                            },
+                            {
                                 "value": "RSCC_OUTLIER",
                                 "detail": "Real space density correlation value < 0.65",
                                 "name": "Real space density correlation outlier"
+                            },
+                            {
+                                "value": "RSR",
+                                "detail": "Real Space R-value",
+                                "name": "RSR"
+                            },
+                            {
+                                "value": "RSRZ",
+                                "detail": "Real Space R-value z-score",
+                                "name": "RSRZ"
                             },
                             {
                                 "value": "RSRZ_OUTLIER",
@@ -21058,6 +22108,11 @@
                                 "value": "STRN",
                                 "detail": "Strand or beta-bridge (protein)",
                                 "name": "Strand or beta-bridge (protein)"
+                            },
+                            {
+                                "value": "SYMM_CLASHES",
+                                "detail": "Number of symmetry related clashes",
+                                "name": "SYMM_CLASHES"
                             },
                             {
                                 "value": "TURN_TY1_P",
@@ -21197,6 +22252,7 @@
                                         "PARTNER_ASYM_ID",
                                         "PARTNER_BOND_DISTANCE",
                                         "PARTNER_COMP_ID",
+                                        "PDB_MODEL_NUM",
                                         "SCOP2_DOMAIN_ID",
                                         "SCOP2_FAMILY_ID",
                                         "SCOP2_FAMILY_NAME",
@@ -21248,6 +22304,10 @@
                                         {
                                             "value": "PARTNER_COMP_ID",
                                             "detail": "Binding Partner Chemical Component Identifier"
+                                        },
+                                        {
+                                            "value": "PDB_MODEL_NUM",
+                                            "detail": "PDB Model Number"
                                         },
                                         {
                                             "value": "SCOP2_DOMAIN_ID",
@@ -21461,12 +22521,17 @@
                         "type": "string",
                         "enum": [
                             "ANGLE_OUTLIER",
+                            "ANGLE_OUTLIERS",
+                            "AVERAGE_OCCUPANCY",
                             "BEND",
                             "BINDING_SITE",
                             "BOND_OUTLIER",
+                            "BOND_OUTLIERS",
                             "C-MANNOSYLATION_SITE",
                             "CATH",
+                            "CHIRAL_OUTLIERS",
                             "CIS-PEPTIDE",
+                            "CLASHES",
                             "ECOD",
                             "HELIX_P",
                             "HELX_LH_PP_P",
@@ -21491,12 +22556,23 @@
                             "MA_QA_METRIC_LOCAL_TYPE_ZSCORE",
                             "MEMBRANE_SEGMENT",
                             "MOGUL_ANGLE_OUTLIER",
+                            "MOGUL_ANGLE_OUTLIERS",
                             "MOGUL_BOND_OUTLIER",
+                            "MOGUL_BOND_OUTLIERS",
+                            "MOGUL_RING_OUTLIERS",
+                            "MOGUL_TORSION_OUTLIERS",
                             "N-GLYCOSYLATION_SITE",
+                            "NATOMS_EDS",
                             "O-GLYCOSYLATION_SITE",
+                            "OWAB",
+                            "PLANE_OUTLIERS",
+                            "Q_SCORE",
                             "RAMACHANDRAN_OUTLIER",
                             "ROTAMER_OUTLIER",
+                            "RSCC",
                             "RSCC_OUTLIER",
+                            "RSR",
+                            "RSRZ",
                             "RSRZ_OUTLIER",
                             "S-GLYCOSYLATION_SITE",
                             "SABDAB_ANTIBODY_HEAVY_CHAIN_SUBCLASS",
@@ -21509,6 +22585,7 @@
                             "SHEET",
                             "STEREO_OUTLIER",
                             "STRN",
+                            "SYMM_CLASHES",
                             "TURN_TY1_P",
                             "UNASSIGNED_SEC_STRUCT",
                             "UNOBSERVED_ATOM_XYZ",
@@ -21532,6 +22609,16 @@
                                 "name": "Molprobity bond angle outlier"
                             },
                             {
+                                "value": "ANGLE_OUTLIERS",
+                                "detail": "Number of atoms with angle outliers",
+                                "name": "ANGLE_OUTLIERS"
+                            },
+                            {
+                                "value": "AVERAGE_OCCUPANCY",
+                                "detail": "The average heavy atom occupancy for coordinate records for the residue",
+                                "name": "AVERAGE_OCCUPANCY"
+                            },
+                            {
                                 "value": "BEND",
                                 "detail": "Bend - region with high backbone curvature without specific hydrogen bonding",
                                 "name": "Bend - region with high backbone curvature without specific hydrogen bonding"
@@ -21547,6 +22634,11 @@
                                 "name": "Molprobity bond distance outlier"
                             },
                             {
+                                "value": "BOND_OUTLIERS",
+                                "detail": "Number of atoms with bond outliers",
+                                "name": "BOND_OUTLIERS"
+                            },
+                            {
                                 "value": "C-MANNOSYLATION_SITE",
                                 "detail": "Mannose glycan binding to the first tryptophan (W) residue in the sequence motif WXXW  (where X is any amino acid).",
                                 "name": "C-Mannosylation Site"
@@ -21557,9 +22649,19 @@
                                 "name": "CATH"
                             },
                             {
+                                "value": "CHIRAL_OUTLIERS",
+                                "detail": "Number of chiral outliers",
+                                "name": "CHIRAL_OUTLIERS"
+                            },
+                            {
                                 "value": "CIS-PEPTIDE",
                                 "detail": "Peptide linkages with CIS configurations",
                                 "name": "CIS Peptide linkages"
+                            },
+                            {
+                                "value": "CLASHES",
+                                "detail": "Number of atoms a with clashes",
+                                "name": "CLASHES"
                             },
                             {
                                 "value": "ECOD",
@@ -21682,9 +22784,29 @@
                                 "name": "Mogul bond angle outlier"
                             },
                             {
+                                "value": "MOGUL_ANGLE_OUTLIERS",
+                                "detail": "Number of angle outliers as reported by MOGUL",
+                                "name": "MOGUL_ANGLE_OUTLIERS"
+                            },
+                            {
                                 "value": "MOGUL_BOND_OUTLIER",
                                 "detail": "Mogul bond distance outlier",
                                 "name": "Mogul bond distance outlier"
+                            },
+                            {
+                                "value": "MOGUL_BOND_OUTLIERS",
+                                "detail": "Number of bond outliers as reported by MOGUL",
+                                "name": "MOGUL_BOND_OUTLIERS"
+                            },
+                            {
+                                "value": "MOGUL_RING_OUTLIERS",
+                                "detail": "Number of atoms with ring outliers as reported by MOGUL",
+                                "name": "MOGUL_RING_OUTLIERS"
+                            },
+                            {
+                                "value": "MOGUL_TORSION_OUTLIERS",
+                                "detail": "Number of torsion angle outliers as reported by MOGUL",
+                                "name": "MOGUL_TORSION_OUTLIERS"
                             },
                             {
                                 "value": "N-GLYCOSYLATION_SITE",
@@ -21692,9 +22814,29 @@
                                 "name": "N-Glycosylation Site"
                             },
                             {
+                                "value": "NATOMS_EDS",
+                                "detail": "Number of atoms in the residue returned by the EDS software",
+                                "name": "NATOMS_EDS"
+                            },
+                            {
                                 "value": "O-GLYCOSYLATION_SITE",
                                 "detail": "Glycan binding to the oxygen atom of serine (Ser) or threonine (Thr) residues",
                                 "name": "O-Glycosylation Site"
+                            },
+                            {
+                                "value": "OWAB",
+                                "detail": "Occupancy-weighted Average B value",
+                                "name": "OWAB"
+                            },
+                            {
+                                "value": "PLANE_OUTLIERS",
+                                "detail": "Number of planar outliers",
+                                "name": "PLANE_OUTLIERS"
+                            },
+                            {
+                                "value": "Q_SCORE",
+                                "detail": "Q_score",
+                                "name": "Q_SCORE"
                             },
                             {
                                 "value": "RAMACHANDRAN_OUTLIER",
@@ -21707,9 +22849,24 @@
                                 "name": "Molprobity rotamer outlier"
                             },
                             {
+                                "value": "RSCC",
+                                "detail": "Real space correlation coefficient",
+                                "name": "RSCC"
+                            },
+                            {
                                 "value": "RSCC_OUTLIER",
                                 "detail": "Real space density correlation value < 0.65",
                                 "name": "Real space density correlation outlier"
+                            },
+                            {
+                                "value": "RSR",
+                                "detail": "Real Space R-value",
+                                "name": "RSR"
+                            },
+                            {
+                                "value": "RSRZ",
+                                "detail": "Real Space R-value z-score",
+                                "name": "RSRZ"
                             },
                             {
                                 "value": "RSRZ_OUTLIER",
@@ -21770,6 +22927,11 @@
                                 "value": "STRN",
                                 "detail": "Strand or beta-bridge (protein)",
                                 "name": "Strand or beta-bridge (protein)"
+                            },
+                            {
+                                "value": "SYMM_CLASHES",
+                                "detail": "Number of symmetry related clashes",
+                                "name": "SYMM_CLASHES"
                             },
                             {
                                 "value": "TURN_TY1_P",
@@ -21892,9 +23054,7 @@
                                         1,
                                         10
                                     ],
-                                    "path": "rcsb_polymer_instance_feature_summary.count",
-                                    "rcsb_current_minimum_value": 1.0,
-                                    "rcsb_current_maximum_value": 2824.0
+                                    "path": "rcsb_polymer_instance_feature_summary.count"
                                 }
                             ]
                         },
@@ -21906,9 +23066,7 @@
                                         1,
                                         10
                                     ],
-                                    "path": "rcsb_polymer_instance_feature_summary.count",
-                                    "rcsb_current_minimum_value": 1.0,
-                                    "rcsb_current_maximum_value": 2825.0
+                                    "path": "rcsb_polymer_instance_feature_summary.count"
                                 }
                             ]
                         },
@@ -23284,7 +24442,7 @@
                             "priority_order": 18
                         }
                     ],
-                    "rcsb_current_maximum_value": 39477986.0,
+                    "rcsb_current_maximum_value": 39779760.0,
                     "rcsb_current_minimum_value": 5.0
                 }
             },
@@ -23432,7 +24590,7 @@
                                 "context": "brief"
                             }
                         ],
-                        "rcsb_current_maximum_value": 1076822.0,
+                        "rcsb_current_maximum_value": 1078320.0,
                         "rcsb_current_minimum_value": 1.0
                     },
                     "identity": {
@@ -31263,7 +32421,9 @@
                         "enum": [
                             "HAS_COVALENT_LINKAGE",
                             "HAS_METAL_COORDINATION_LINKAGE",
-                            "HAS_NO_COVALENT_LINKAGE"
+                            "HAS_NO_COVALENT_LINKAGE",
+                            "IS_RSCC_OUTLIER",
+                            "IS_RSRZ_OUTLIER"
                         ],
                         "examples": [
                             "HAS_COVALENT_LINKAGE"
@@ -31288,6 +32448,16 @@
                                 "value": "HAS_NO_COVALENT_LINKAGE",
                                 "detail": "Ligands with no inter-molecular covalent interactions, but may be involved in metal coordination or other non-bonded interactions",
                                 "name": "Has No Covalent Linkage"
+                            },
+                            {
+                                "value": "IS_RSCC_OUTLIER",
+                                "detail": "Non-polymer is a real space density correlation value outlier (< 0.65)",
+                                "name": "Real space density correlation value outlier"
+                            },
+                            {
+                                "value": "IS_RSRZ_OUTLIER",
+                                "detail": "Non-polymer is a real space R-value Z score outlier (> 2)",
+                                "name": "Real space R-value Z score outlier"
                             }
                         ],
                         "rcsb_description": [
@@ -31522,11 +32692,17 @@
                         "enum": [
                             "HAS_COVALENT_LINKAGE",
                             "HAS_METAL_COORDINATION_LINKAGE",
+                            "MODELED_ATOMS",
                             "MOGUL_ANGLE_OUTLIER",
+                            "MOGUL_ANGLE_OUTLIERS",
                             "MOGUL_BOND_OUTLIER",
+                            "MOGUL_BOND_OUTLIERS",
+                            "MOGUL_RING_OUTLIERS",
+                            "MOGUL_TORSION_OUTLIERS",
                             "RSCC_OUTLIER",
                             "RSRZ_OUTLIER",
-                            "STEREO_OUTLIER"
+                            "STEREO_OUTLIER",
+                            "STEREO_OUTLIERS"
                         ],
                         "examples": [
                             "RSRZ_OUTLIER",
@@ -31543,12 +32719,32 @@
                                 "detail": "Has a metal coordination attachment"
                             },
                             {
+                                "value": "MODELED_ATOMS",
+                                "detail": "Number of modeled atoms"
+                            },
+                            {
                                 "value": "MOGUL_ANGLE_OUTLIER",
                                 "detail": "Mogul bond angle outlier"
                             },
                             {
+                                "value": "MOGUL_ANGLE_OUTLIERS",
+                                "detail": "Number of angle outliers as reported by MOGUL"
+                            },
+                            {
                                 "value": "MOGUL_BOND_OUTLIER",
                                 "detail": "Mogul bond distance outlier"
+                            },
+                            {
+                                "value": "MOGUL_BOND_OUTLIERS",
+                                "detail": "Number of bond outliers as reported by MOGUL"
+                            },
+                            {
+                                "value": "MOGUL_RING_OUTLIERS",
+                                "detail": "Number of ring outliers as reported by MOGUL"
+                            },
+                            {
+                                "value": "MOGUL_TORSION_OUTLIERS",
+                                "detail": "Number of torsion outliers as reported by MOGUL"
                             },
                             {
                                 "value": "RSCC_OUTLIER",
@@ -31561,6 +32757,10 @@
                             {
                                 "value": "STEREO_OUTLIER",
                                 "detail": "Stereochemical/chirality outlier"
+                            },
+                            {
+                                "value": "STEREO_OUTLIERS",
+                                "detail": "Number of stereo outliers"
                             }
                         ],
                         "rcsb_description": [
@@ -31777,6 +32977,20 @@
                             }
                         ]
                     },
+                    "coverage": {
+                        "type": "number",
+                        "examples": [
+                            0.5,
+                            0.95
+                        ],
+                        "description": "The fractional feature coverage relative to the full entity sequence.",
+                        "rcsb_description": [
+                            {
+                                "text": "The fractional feature coverage relative to the full entity sequence.",
+                                "context": "dictionary"
+                            }
+                        ]
+                    },
                     "maximum_length": {
                         "type": "integer",
                         "description": "The maximum feature length.",
@@ -31830,11 +33044,17 @@
                         "enum": [
                             "HAS_COVALENT_LINKAGE",
                             "HAS_METAL_COORDINATION_LINKAGE",
+                            "MODELED_ATOMS",
                             "MOGUL_ANGLE_OUTLIER",
+                            "MOGUL_ANGLE_OUTLIERS",
                             "MOGUL_BOND_OUTLIER",
+                            "MOGUL_BOND_OUTLIERS",
+                            "MOGUL_RING_OUTLIERS",
+                            "MOGUL_TORSION_OUTLIERS",
                             "RSCC_OUTLIER",
                             "RSRZ_OUTLIER",
-                            "STEREO_OUTLIER"
+                            "STEREO_OUTLIER",
+                            "STEREO_OUTLIERS"
                         ],
                         "examples": [
                             "RSRZ_OUTLIER",
@@ -31855,12 +33075,32 @@
                                 "detail": "Has a metal coordination attachment"
                             },
                             {
+                                "value": "MODELED_ATOMS",
+                                "detail": "Number of modeled atoms"
+                            },
+                            {
                                 "value": "MOGUL_ANGLE_OUTLIER",
                                 "detail": "Mogul bond angle outlier"
                             },
                             {
+                                "value": "MOGUL_ANGLE_OUTLIERS",
+                                "detail": "Number of angle outliers as reported by MOGUL"
+                            },
+                            {
                                 "value": "MOGUL_BOND_OUTLIER",
                                 "detail": "Mogul bond distance outlier"
+                            },
+                            {
+                                "value": "MOGUL_BOND_OUTLIERS",
+                                "detail": "Number of bond outliers as reported by MOGUL"
+                            },
+                            {
+                                "value": "MOGUL_RING_OUTLIERS",
+                                "detail": "Number of ring outliers as reported by MOGUL"
+                            },
+                            {
+                                "value": "MOGUL_TORSION_OUTLIERS",
+                                "detail": "Number of torsion outliers as reported by MOGUL"
                             },
                             {
                                 "value": "RSCC_OUTLIER",
@@ -31873,6 +33113,10 @@
                             {
                                 "value": "STEREO_OUTLIER",
                                 "detail": "Stereochemical/chirality outlier"
+                            },
+                            {
+                                "value": "STEREO_OUTLIERS",
+                                "detail": "Number of stereo outliers"
                             }
                         ],
                         "rcsb_description": [
@@ -31905,9 +33149,7 @@
                                         1,
                                         5
                                     ],
-                                    "path": "rcsb_nonpolymer_instance_feature_summary.count",
-                                    "rcsb_current_minimum_value": 1.0,
-                                    "rcsb_current_maximum_value": 102.0
+                                    "path": "rcsb_nonpolymer_instance_feature_summary.count"
                                 }
                             ]
                         },
@@ -31919,9 +33161,7 @@
                                         1,
                                         5
                                     ],
-                                    "path": "rcsb_nonpolymer_instance_feature_summary.count",
-                                    "rcsb_current_minimum_value": 1.0,
-                                    "rcsb_current_maximum_value": 166.0
+                                    "path": "rcsb_nonpolymer_instance_feature_summary.count"
                                 }
                             ]
                         },
@@ -31933,9 +33173,7 @@
                                         1,
                                         5
                                     ],
-                                    "path": "rcsb_nonpolymer_instance_feature_summary.count",
-                                    "rcsb_current_minimum_value": 1.0,
-                                    "rcsb_current_maximum_value": 2883.0
+                                    "path": "rcsb_nonpolymer_instance_feature_summary.count"
                                 }
                             ]
                         },
@@ -31947,9 +33185,7 @@
                                         1,
                                         5
                                     ],
-                                    "path": "rcsb_nonpolymer_instance_feature_summary.count",
-                                    "rcsb_current_minimum_value": 1.0,
-                                    "rcsb_current_maximum_value": 3000.0
+                                    "path": "rcsb_nonpolymer_instance_feature_summary.count"
                                 }
                             ]
                         },
@@ -31961,9 +33197,7 @@
                                         1,
                                         5
                                     ],
-                                    "path": "rcsb_nonpolymer_instance_feature_summary.count",
-                                    "rcsb_current_minimum_value": 1.0,
-                                    "rcsb_current_maximum_value": 77.0
+                                    "path": "rcsb_nonpolymer_instance_feature_summary.count"
                                 }
                             ]
                         },
@@ -32088,7 +33322,7 @@
                                 "context": "brief"
                             }
                         ],
-                        "rcsb_current_maximum_value": 95.0,
+                        "rcsb_current_maximum_value": 140.0,
                         "rcsb_current_minimum_value": 0.0
                     },
                     "is_best_instance": {
@@ -32216,14 +33450,14 @@
                             7.22,
                             1.16
                         ],
-                        "description": "The root-mean-square value of the Z-scores of bond angles for the residue in degrees\nobtained from a CCDC Mogul survey of bond angles in the CSD small molecule crystal structure database.",
+                        "description": "The root-mean-square value of the Z-scores of bond angles for the non-polymer instance in degrees\nobtained from a CCDC Mogul survey of bond angles in the CSD small molecule crystal structure database.",
                         "rcsb_search_context": [
                             "default-match"
                         ],
                         "rcsb_units": "degrees",
                         "rcsb_description": [
                             {
-                                "text": "The root-mean-square value of the Z-scores of bond angles for the residue in degrees\nobtained from a CCDC Mogul survey of bond angles in the CSD small molecule crystal structure database.",
+                                "text": "The root-mean-square value of the Z-scores of bond angles for the non-polymer instance in degrees\nobtained from a CCDC Mogul survey of bond angles in the CSD small molecule crystal structure database.",
                                 "context": "dictionary"
                             },
                             {
@@ -32259,14 +33493,14 @@
                             0.69,
                             1.32
                         ],
-                        "description": "The root-mean-square value of the Z-scores of bond lengths for the residue in Angstroms\nobtained from a CCDC Mogul survey of bond lengths in the CSD small molecule crystal structure database.",
+                        "description": "The root-mean-square value of the Z-scores of bond lengths for the nonpolymer instance in Angstroms\nobtained from a CCDC Mogul survey of bond lengths in the CSD small molecule crystal structure database.",
                         "rcsb_search_context": [
                             "default-match"
                         ],
                         "rcsb_units": "angstroms",
                         "rcsb_description": [
                             {
-                                "text": "The root-mean-square value of the Z-scores of bond lengths for the residue in Angstroms\nobtained from a CCDC Mogul survey of bond lengths in the CSD small molecule crystal structure database.",
+                                "text": "The root-mean-square value of the Z-scores of bond lengths for the nonpolymer instance in Angstroms\nobtained from a CCDC Mogul survey of bond lengths in the CSD small molecule crystal structure database.",
                                 "context": "dictionary"
                             },
                             {
@@ -32276,6 +33510,36 @@
                         ],
                         "rcsb_current_maximum_value": 1108.53,
                         "rcsb_current_minimum_value": 0.0
+                    },
+                    "natoms_eds": {
+                        "type": "integer",
+                        "description": "The number of atoms in the non-polymer instance returned by the EDS software.",
+                        "rcsb_description": [
+                            {
+                                "text": "The number of atoms in the non-polymer instance returned by the EDS software.",
+                                "context": "dictionary"
+                            }
+                        ]
+                    },
+                    "num_mogul_angles_RMSZ": {
+                        "type": "integer",
+                        "description": "The number of bond angles compared to \"standard geometry\" made using the Mogul program.",
+                        "rcsb_description": [
+                            {
+                                "text": "The number of bond angles compared to \"standard geometry\" made using the Mogul program.",
+                                "context": "dictionary"
+                            }
+                        ]
+                    },
+                    "num_mogul_bonds_RMSZ": {
+                        "type": "integer",
+                        "description": "The number of bond lengths compared to \"standard geometry\" made using the Mogul program.",
+                        "rcsb_description": [
+                            {
+                                "text": "The number of bond lengths compared to \"standard geometry\" made using the Mogul program.",
+                                "context": "dictionary"
+                            }
+                        ]
                     },
                     "ranking_model_fit": {
                         "type": "number",
@@ -33951,5 +35215,5 @@
     "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "Text Service Metadata",
     "description": "",
-    "$comment": "Schema version: 1.47.7"
+    "$comment": "Schema version: 1.48.0"
 }


### PR DESCRIPTION
Version 1.0.1
- Import `annotations` in `const.py` file for compatibility with Python 3.8
- Update search API schema
- Fixes to Azure pipeline