### PR TITLE
v1.1.3 - Fix: Update regex pattern for instances in `const.py`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
+## v1.1.3 (2025-05-05)
+
+- Fix: Update regex pattern for instances in `const.py` to support suffixes longer than one character (e.g., "1S5L.AA")
+
 ## v1.1.2 (2025-03-20)
 
-- Update how `dataclass` attributes are created in `const.py` 
+- Update how `dataclass` attributes are created in `const.py`
 
 ## v1.1.1 (2025-03-13)
 

--- a/rcsbapi/__init__.py
+++ b/rcsbapi/__init__.py
@@ -2,7 +2,7 @@ __docformat__ = "restructuredtext en"
 __author__ = "Dennis Piehl"
 __email__ = "dennis.piehl@rcsb.org"
 __license__ = "MIT"
-__version__ = "1.1.2"
+__version__ = "1.1.3"
 
 __path__ = __import__("pkgutil").extend_path(__path__, __name__)
 

--- a/rcsbapi/const.py
+++ b/rcsbapi/const.py
@@ -90,7 +90,7 @@ class Const:
     DATA_API_INPUT_TYPE_TO_REGEX: MappingProxyType[str, List[str]] = field(default_factory=lambda: MappingProxyType({
         "entry": [r"^(MA|AF|ma|af)_[A-Z0-9]*$", r"^[A-Za-z0-9]{4}$"],
         "entity": [r"^(MA|AF|ma|af)_[A-Z0-9]*_[0-9]+$", r"^[A-Z0-9]{4}_[0-9]+$"],
-        "instance": [r"^(MA|AF|ma|af)_[A-Z0-9]*\.[A-Za-z]$", r"^[A-Z0-9]{4}\.[A-Za-z]$"],
+        "instance": [r"^(MA|AF|ma|af)_[A-Z0-9]*\.[A-Za-z]+$", r"^[A-Z0-9]{4}\.[A-Za-z]+$"],
         "assembly": [r"^(MA|AF|ma|af)_[A-Z0-9]*-[0-9]+$", r"^[A-Z0-9]{4}-[0-9]+$"],
         "interface": [r"^(MA|AF|ma|af)_[A-Z0-9]*-[0-9]+\.[0-9]+$", r"^[A-Z0-9]{4}-[0-9]+\.[0-9]+$"],
         # Regex for uniprot: https://www.uniprot.org/help/accession_numbers


### PR DESCRIPTION
Update regex pattern for instances in `const.py` to support suffixes longer than one character (e.g., "1S5L.AA").