### PR TITLE
v1.1.4 - Fix: Patch schema parsing for search attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v1.1.4 (2025-07-09)
+
+- Fix: Patch schema parsing for search attributes to delete duplicate chemical attributes from structure attribute schema (following update to RCSB.org schemas in July 2025, in which chemical attributes are now merged into structure attribute schema)
+
 ## v1.1.3 (2025-05-05)
 
 - Fix: Update regex pattern for instances in `const.py` to support suffixes longer than one character (e.g., "1S5L.AA")

--- a/rcsbapi/__init__.py
+++ b/rcsbapi/__init__.py
@@ -2,7 +2,7 @@ __docformat__ = "restructuredtext en"
 __author__ = "Dennis Piehl"
 __email__ = "dennis.piehl@rcsb.org"
 __license__ = "MIT"
-__version__ = "1.1.3"
+__version__ = "1.1.4"
 
 __path__ = __import__("pkgutil").extend_path(__path__, __name__)
 

--- a/rcsbapi/search/search_schema.py
+++ b/rcsbapi/search/search_schema.py
@@ -194,6 +194,11 @@ class SearchSchema:
         if reload:
             self.struct_schema = self._reload_schema(struct_attr_schema_url, struct_attr_schema_file, refetch, use_fallback)
             self.chem_schema = self._reload_schema(chem_attr_schema_url, chem_attr_schema_file, refetch, use_fallback)
+            # Patch: delete duplicate chemical attributes from structure schema (after chemical attrs were merged in July 2025)
+            chem_keys = self.chem_schema["properties"].keys()
+            for k in chem_keys:
+                if k != "rcsb_id" and k in self.struct_schema["properties"]:  # delete duplicate keys EXCEPT "rcsb_id"
+                    _ = self.struct_schema["properties"].pop(k)
         self.search_attributes = self._make_schema_group()
 
     def _reload_schema(self, schema_url: str, schema_file: str, refetch=True, use_fallback=True):


### PR DESCRIPTION
v1.1.4 - Fix: Patch schema parsing for search attributes - this will delete duplicate chemical attributes from structure attribute schema (following update to RCSB.org schemas in July 2025, in which chemical attributes are now merged into structure attribute schema)

Addresses the error reported here https://github.com/rcsb/py-rcsb-api/issues/70, but represents a global issue that will impact all users, since the RCSB.org schema is shared by everyone.

