### PR TITLE
Switch from requests to httpx; Add asynchronous support for Data API

### DIFF
--- a/rcsbapi/config.py
+++ b/rcsbapi/config.py
@@ -19,11 +19,13 @@ logger = logging.getLogger(__name__)
 
 
 class Config:
-    API_TIMEOUT: int = 60
+    API_TIMEOUT: int = 100                       # Timeout in seconds for all API calls
     SEARCH_API_REQUESTS_PER_SECOND: int = 10
     MODEL_API_REQUESTS_PER_SECOND: int = 10
-    SUPPRESS_AUTOCOMPLETE_WARNING: bool = False
-    INPUT_ID_LIMIT: int = 5000
+    SUPPRESS_AUTOCOMPLETE_WARNING: bool = False  # Turn off autocompletion warnings from being raised for Data API queries
+    DATA_API_BATCH_ID_SIZE: int = 200            # Size of batches to use for batching input ID list to Data API (reduce this if encountering timeouts or errors)
+    DATA_API_MAX_CONCURRENT_REQUESTS: int = 5    # Max number of Data API requests to run concurrently (e.g., when input ID list is split into many small batches)
+    INPUT_ID_LIMIT: int = 5000                   # Threshold for warning user that input ID list for Data API query is very large and may hinder performance
 
     def __setattr__(self, name: str, value: Any) -> None:
         """Verify attribute exists when a user tries to set a configuration parameter, and ensure proper typing.

--- a/rcsbapi/dev_tools/update_schema.py
+++ b/rcsbapi/dev_tools/update_schema.py
@@ -13,7 +13,7 @@ are in the .const file.
 import json
 from pathlib import Path
 from typing import Dict, Literal, List
-import requests
+import httpx
 
 try:
     from rcsbapi.search.search_query import SEARCH_SCHEMA  # instance of SearchSchema
@@ -117,10 +117,10 @@ if __name__ == "__main__":
         data_version_dict[file_name] = data_version
 
     # Update full GraphQL Data API schema
-    schema_response = requests.post(
+    schema_response = httpx.post(
+        url=const.DATA_API_ENDPOINT,
         headers={"Content-Type": "application/json", "User-Agent": const.USER_AGENT},
         json=DATA_SCHEMA.introspection_query,
-        url=const.DATA_API_ENDPOINT,
         timeout=config.API_TIMEOUT
     )
     assert schema_response.status_code == 200
@@ -129,10 +129,10 @@ if __name__ == "__main__":
         json.dump(schema_response.json(), f, indent=4)
 
     # Update full GraphQL Sequence API schema
-    schema_response = requests.post(
+    schema_response = httpx.post(
+        url=const.SEQUENCE_API_GRAPHQL_ENDPOINT,
         headers={"Content-Type": "application/json", "User-Agent": const.USER_AGENT},
         json=SEQ_SCHEMA.introspection_query,
-        url=const.SEQUENCE_API_GRAPHQL_ENDPOINT,
         timeout=config.API_TIMEOUT
     )
     assert schema_response.status_code == 200
@@ -144,8 +144,8 @@ if __name__ == "__main__":
     model_schema_url = const.MODELSERVER_API_SCHEMA_URL
     model_schema_path = Path(__file__).parent.parent.joinpath(const.MODELSERVER_API_SCHEMA_FILEPATH)
 
-    model_schema_response = requests.get(
-        model_schema_url,
+    model_schema_response = httpx.get(
+        url=model_schema_url,
         headers={"User-Agent": const.USER_AGENT},
         timeout=config.API_TIMEOUT
     )

--- a/rcsbapi/graphql_schema.py
+++ b/rcsbapi/graphql_schema.py
@@ -5,7 +5,7 @@ from typing import Dict, List, Tuple, Any
 import json
 import logging
 from pathlib import Path
-import requests
+import httpx
 from graphql import validate, parse, build_client_schema
 import rustworkx as rx
 from rcsbapi.const import const
@@ -191,7 +191,7 @@ class GQLSchema(ABC):
         { name description type{ kind ofType{ name kind ofType{ inputFields {name type { kind ofType { name kind ofType { ofType { kind name ofType {kind name}} } } } }
         kind name ofType{name kind} } } } } } } } }"""
         }
-        response = requests.post(
+        response = httpx.post(
             headers={"Content-Type": "application/json", "User-Agent": const.USER_AGENT},
             json=root_query,
             url=self.pdb_url,
@@ -247,7 +247,7 @@ class GQLSchema(ABC):
         Returns:
             Dict: JSON response of introspection request
         """
-        schema_response = requests.post(
+        schema_response = httpx.post(
             headers={"Content-Type": "application/json", "User-Agent": const.USER_AGENT},
             json=self.introspection_query,
             url=self.pdb_url,

--- a/rcsbapi/model/model_query.py
+++ b/rcsbapi/model/model_query.py
@@ -3,7 +3,7 @@ import time
 from typing import Optional, Literal, List
 import urllib.parse
 import gzip
-import requests
+import httpx
 from rcsbapi.const import const
 from rcsbapi.config import config
 
@@ -75,7 +75,7 @@ class ModelQuery:
                 time.sleep(1)
                 self._request_counter = 0
 
-            response = requests.get(full_url, timeout=config.API_TIMEOUT, headers={"Content-Type": "application/json", "User-Agent": const.USER_AGENT})  # Use the constructed URL
+            response = httpx.get(full_url, timeout=config.API_TIMEOUT, headers={"Content-Type": "application/json", "User-Agent": const.USER_AGENT})  # Use the constructed URL
             response.raise_for_status()  # Raise an error for bad responses
 
             # Get encoding type (defaults to CIF if not provided)
@@ -151,7 +151,7 @@ class ModelQuery:
             # Return the file path of the downloaded file
             return file_path
 
-        except requests.exceptions.RequestException as e:
+        except (httpx.RequestError, httpx.HTTPStatusError) as e:
             print(f"An error occurred: {e}")
             return None
 

--- a/rcsbapi/model/model_schema.py
+++ b/rcsbapi/model/model_schema.py
@@ -1,5 +1,5 @@
 from typing import Dict, List, Optional
-import requests
+import httpx
 from rcsbapi.const import const
 from rcsbapi.config import config
 
@@ -10,10 +10,11 @@ class ModelSchema:
         Initialize ModelSchema.
         """
         try:
-            response = requests.get(const.MODELSERVER_API_SCHEMA_URL, timeout=config.API_TIMEOUT, headers={"Content-Type": "application/json", "User-Agent": const.USER_AGENT})
+            url = url if url else const.MODELSERVER_API_SCHEMA_URL
+            response = httpx.get(url, timeout=config.API_TIMEOUT, headers={"Content-Type": "application/json", "User-Agent": const.USER_AGENT})
             response.raise_for_status()
             attr_data = response.json()
-        except requests.RequestException as e:
+        except (httpx.RequestError, httpx.HTTPStatusError) as e:
             raise RuntimeError(f"Failed to fetch schema from {url}: {e}")
 
         self.Attr = attr_data

--- a/rcsbapi/search/search_schema.py
+++ b/rcsbapi/search/search_schema.py
@@ -9,7 +9,7 @@ from pathlib import Path
 import re
 import warnings
 from typing import List, Dict, Union
-import requests
+import httpx
 from rcsbapi.const import const
 
 logger = logging.getLogger(__name__)
@@ -220,7 +220,7 @@ class SearchSchema:
     def _fetch_schema(self, url: str):
         "Request the current schema from the web"
         logger.info("Requesting %s", url)
-        response = requests.get(url, timeout=None, headers={"User-Agent": const.USER_AGENT})
+        response = httpx.get(url, timeout=None, headers={"User-Agent": const.USER_AGENT})
         if response.status_code == 200:
             return response.json()
         else:

--- a/rcsbapi/sequence/seq_query.py
+++ b/rcsbapi/sequence/seq_query.py
@@ -4,7 +4,7 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass, fields
 from dataclasses import field as dcfield
 import urllib.parse
-import requests
+import httpx
 
 from rcsbapi.const import const
 from rcsbapi.config import config
@@ -90,7 +90,7 @@ class SeqQuery(ABC):
         # Assert attribute exists for mypy
         assert hasattr(self, "_query"), \
             f"{self.__class__.__name__} must define '_query' attribute."
-        response_json = requests.post(
+        response_json = httpx.post(
             json=dict(self._query),
             url=const.SEQUENCE_API_GRAPHQL_ENDPOINT,
             timeout=config.API_TIMEOUT,
@@ -109,7 +109,7 @@ class SeqQuery(ABC):
         """Look through responses to see if there are errors. If so, throw an HTTP error, """
         if "errors" in response_json.keys():
             error = response_json["errors"][0]
-            raise requests.HTTPError(
+            raise Exception(
                 f'\n{error["message"]}\n'
                 f"Run <query object name>.get_editor_link() to get a link to GraphiQL editor with query"
             )

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-requests >= 2.0.0
+httpx >= 0.26.0
 rustworkx
 graphql-core
 tqdm

--- a/tests/test_data_query.py
+++ b/tests/test_data_query.py
@@ -14,7 +14,7 @@ Tests for all functions of the Data API module.
 import logging
 import time
 import unittest
-import requests
+import httpx
 
 from rcsbapi.search import search_attributes as attrs
 from rcsbapi.search import NestedAttributeQuery, AttributeQuery
@@ -39,7 +39,7 @@ class QueryTests(unittest.TestCase):
         # query_str = '{ entries(entry_ids: ["4HHB", "1IYE"]) {\n  exptl {\n     method_details\n     method\n     details\n     crystals_number\n  }\n}}'
         query_obj = DataQuery(input_type="entries", input_ids={"entry_ids": ["4HHB", "1IYE"]}, return_data_list=["exptl"])
         url = query_obj.get_editor_link()
-        response_json = requests.get(url, timeout=10)
+        response_json = httpx.get(url, timeout=10)
         self.assertEqual(response_json.status_code, 200)
 
     def testExec(self) -> None:
@@ -183,7 +183,7 @@ class QueryTests(unittest.TestCase):
         with self.subTest(msg=msg):
             logger.info("Running subtest %s", msg)
             query = DataQuery(input_type="entries", input_ids=["4HHB"], return_data_list=["exptl"])
-            response = requests.get(query.get_editor_link(), timeout=5)
+            response = httpx.get(query.get_editor_link(), timeout=5)
             self.assertEqual(response.status_code, 200)
 
         msg = "5. Helpful methods, find_paths()"
@@ -384,7 +384,7 @@ class QueryTests(unittest.TestCase):
             }
             }
             """
-            response_json = requests.post(headers={"Content-Type": "application/graphql"}, data=ex_query, url=const.DATA_API_ENDPOINT, timeout=config.API_TIMEOUT).json()
+            response_json = httpx.post(headers={"Content-Type": "application/graphql"}, data=ex_query, url=const.DATA_API_ENDPOINT, timeout=config.API_TIMEOUT).json()
             self.assertNotIn("errors", response_json.keys())
 
         msg = "4. Making Queries"

--- a/tests/test_data_schema.py
+++ b/tests/test_data_schema.py
@@ -16,7 +16,7 @@ import time
 import json
 import os
 import unittest
-import requests
+import httpx
 
 from rcsbapi.data import DATA_SCHEMA
 from rcsbapi.config import config
@@ -46,7 +46,7 @@ class SchemaTests(unittest.TestCase):
             local_major_minor_version = ".".join(local_schema_version.split(".")[:2])
 
             online_schema_url = "https://data.rcsb.org/rest/v1/schema/entry"
-            response = requests.get(online_schema_url, timeout=config.API_TIMEOUT)
+            response = httpx.get(online_schema_url, timeout=config.API_TIMEOUT)
             online_schema_data = response.json()
             online_schema_version = online_schema_data.get("$comment").split(": ")[1]
             online_major_minor_version = ".".join(online_schema_version.split(".")[:2])
@@ -62,7 +62,7 @@ class SchemaTests(unittest.TestCase):
             local_major_minor_version = ".".join(local_schema_version.split(".")[:2])
 
             online_schema_url = "https://data.rcsb.org/rest/v1/schema/polymer_entity"
-            response = requests.get(online_schema_url, timeout=config.API_TIMEOUT)
+            response = httpx.get(online_schema_url, timeout=config.API_TIMEOUT)
             online_schema_data = response.json()
             online_schema_version = online_schema_data.get("$comment").split(": ")[1]
             online_major_minor_version = ".".join(online_schema_version.split(".")[:2])
@@ -84,7 +84,7 @@ class SchemaTests(unittest.TestCase):
             local_major_minor_version = ".".join(local_schema_version.split(".")[:2])
 
             online_schema_url = "https://data.rcsb.org/rest/v1/schema/polymer_entity_instance"
-            response = requests.get(online_schema_url, timeout=config.API_TIMEOUT)
+            response = httpx.get(online_schema_url, timeout=config.API_TIMEOUT)
             online_schema_data = response.json()
             online_schema_version = online_schema_data.get("$comment").split(": ")[1]
             online_major_minor_version = ".".join(online_schema_version.split(".")[:2])
@@ -169,21 +169,21 @@ class SchemaTests(unittest.TestCase):
         with self.subTest(msg=msg):
             logger.info("Running subtest %s", msg)
             query = DATA_SCHEMA.construct_query(input_ids={"entry_id": "4HHB"}, input_type="entry", return_data_list=["exptl"])
-            response_json = requests.post(headers={"Content-Type": "application/json"}, json=query, url=const.DATA_API_ENDPOINT, timeout=config.API_TIMEOUT).json()
+            response_json = httpx.post(headers={"Content-Type": "application/json"}, json=query, url=const.DATA_API_ENDPOINT, timeout=config.API_TIMEOUT).json()
             self.assertNotIn("errors", response_json.keys())
 
         msg = "2. plural input_type (entries)"
         with self.subTest(msg=msg):
             logger.info("Running subtest %s", msg)
             query = DATA_SCHEMA.construct_query(input_ids={"entry_ids": ["4HHB", "1IYE"]}, input_type="entries", return_data_list=["exptl"])
-            response_json = requests.post(headers={"Content-Type": "application/json"}, json=query, url=const.DATA_API_ENDPOINT, timeout=config.API_TIMEOUT).json()
+            response_json = httpx.post(headers={"Content-Type": "application/json"}, json=query, url=const.DATA_API_ENDPOINT, timeout=config.API_TIMEOUT).json()
             self.assertNotIn("errors", response_json.keys())
 
         msg = "3. two arguments (polymer_entity_instance)"
         with self.subTest(msg=msg):
             logger.info("Running subtest %s", msg)
             query = DATA_SCHEMA.construct_query(input_ids={"asym_id": "A", "entry_id": "4HHB"}, input_type="polymer_entity_instance", return_data_list=["exptl"])
-            response_json = requests.post(headers={"Content-Type": "application/json"}, json=query, url=const.DATA_API_ENDPOINT, timeout=config.API_TIMEOUT).json()
+            response_json = httpx.post(headers={"Content-Type": "application/json"}, json=query, url=const.DATA_API_ENDPOINT, timeout=config.API_TIMEOUT).json()
             self.assertNotIn("errors", response_json.keys())
 
         msg = "4. three arguments (interface)"
@@ -192,21 +192,21 @@ class SchemaTests(unittest.TestCase):
             query = DATA_SCHEMA.construct_query(
                 input_ids={"assembly_id": "1", "interface_id": "1", "entry_id": "4HHB"}, input_type="interface", return_data_list=["interface.rcsb_id"]
             )
-            response_json = requests.post(headers={"Content-Type": "application/json"}, json=query, url=const.DATA_API_ENDPOINT, timeout=config.API_TIMEOUT).json()
+            response_json = httpx.post(headers={"Content-Type": "application/json"}, json=query, url=const.DATA_API_ENDPOINT, timeout=config.API_TIMEOUT).json()
             self.assertNotIn("errors", response_json.keys())
 
         msg = "5. request multiple return fields"
         with self.subTest(msg=msg):
             logger.info("Running subtest %s", msg)
             query = DATA_SCHEMA.construct_query(input_ids={"entry_id": "4HHB"}, input_type="entry", return_data_list=["exptl", "rcsb_polymer_instance_annotation"])
-            response_json = requests.post(headers={"Content-Type": "application/json"}, json=query, url=const.DATA_API_ENDPOINT, timeout=config.API_TIMEOUT).json()
+            response_json = httpx.post(headers={"Content-Type": "application/json"}, json=query, url=const.DATA_API_ENDPOINT, timeout=config.API_TIMEOUT).json()
             self.assertNotIn("errors", response_json.keys())
 
         msg = "6. request scalar field"
         with self.subTest(msg=msg):
             logger.info("Running subtest %s", msg)
             query = DATA_SCHEMA.construct_query(input_ids={"entry_id": "4HHB"}, input_type="entry", return_data_list=["entry.rcsb_id"])
-            response_json = requests.post(headers={"Content-Type": "application/json"}, json=query, url=const.DATA_API_ENDPOINT, timeout=config.API_TIMEOUT).json()
+            response_json = httpx.post(headers={"Content-Type": "application/json"}, json=query, url=const.DATA_API_ENDPOINT, timeout=config.API_TIMEOUT).json()
             self.assertNotIn("errors", response_json.keys())
 
         # Test error handling
@@ -246,21 +246,21 @@ class SchemaTests(unittest.TestCase):
             query = DATA_SCHEMA.construct_query(
                 input_ids={"instance_ids": ["4HHB.A", "4HHB.C"]}, input_type="polymer_entity_instances", return_data_list=["rcsb_polymer_instance_annotation"]
             )
-            response_json = requests.post(headers={"Content-Type": "application/json"}, json=query, url=const.DATA_API_ENDPOINT, timeout=config.API_TIMEOUT).json()
+            response_json = httpx.post(headers={"Content-Type": "application/json"}, json=query, url=const.DATA_API_ENDPOINT, timeout=config.API_TIMEOUT).json()
             self.assertNotIn("errors", response_json.keys())
 
         msg = "13. nested query"
         with self.subTest(msg=msg):
             logger.info("Running subtest %s", msg)
             query = DATA_SCHEMA.construct_query(input_type="interfaces", return_data_list=["rcsb_interface_partner"], input_ids=["MA_MACOFFESLACC100000G1I2-1.1", "7XIW-1.2"])
-            response_json = requests.post(headers={"Content-Type": "application/json"}, json=query, url=const.DATA_API_ENDPOINT, timeout=config.API_TIMEOUT).json()
+            response_json = httpx.post(headers={"Content-Type": "application/json"}, json=query, url=const.DATA_API_ENDPOINT, timeout=config.API_TIMEOUT).json()
             self.assertNotIn("errors", response_json.keys())
 
         msg = "14. requesting scalars under same field"
         with self.subTest(msg=msg):
             logger.info("Running subtest %s", msg)
             query = DATA_SCHEMA.construct_query(input_type="entry", return_data_list=["exptl.method", "exptl.details"], input_ids=["4HHB"])
-            response_json = requests.post(headers={"Content-Type": "application/json"}, json=query, url=const.DATA_API_ENDPOINT, timeout=config.API_TIMEOUT).json()
+            response_json = httpx.post(headers={"Content-Type": "application/json"}, json=query, url=const.DATA_API_ENDPOINT, timeout=config.API_TIMEOUT).json()
             self.assertNotIn("errors", response_json.keys())
 
     def regexChecks(self) -> None:
@@ -270,7 +270,7 @@ class SchemaTests(unittest.TestCase):
             query = DATA_SCHEMA.construct_query(
                 input_type="polymer_entity_instances", return_data_list=["rcsb_polymer_instance_annotation"], input_ids=["4HHB.A", "AF_AFA0A009IHW8F1.B"]
             )
-            response_json = requests.post(headers={"Content-Type": "application/json"}, json=query, url=const.DATA_API_ENDPOINT, timeout=config.API_TIMEOUT).json()
+            response_json = httpx.post(headers={"Content-Type": "application/json"}, json=query, url=const.DATA_API_ENDPOINT, timeout=config.API_TIMEOUT).json()
             logger.info("response: %r", response_json)
             self.assertNotIn("errors", response_json.keys())
 
@@ -280,7 +280,7 @@ class SchemaTests(unittest.TestCase):
             query = DATA_SCHEMA.construct_query(
                 input_type="polymer_entities", return_data_list=["rcsb_polymer_entity_feature"], input_ids=["AF_AFA0A009IHW8F1_1", "4HHB_1"]
             )
-            response_json = requests.post(headers={"Content-Type": "application/json"}, json=query, url=const.DATA_API_ENDPOINT, timeout=config.API_TIMEOUT).json()
+            response_json = httpx.post(headers={"Content-Type": "application/json"}, json=query, url=const.DATA_API_ENDPOINT, timeout=config.API_TIMEOUT).json()
             logger.info("response: %r", response_json)
             self.assertNotIn("errors", response_json.keys())
 
@@ -288,7 +288,7 @@ class SchemaTests(unittest.TestCase):
         with self.subTest(msg=msg):
             logger.info("Running subtest %s", msg)
             query = DATA_SCHEMA.construct_query(input_type="entries", return_data_list=["exptl"], input_ids=["7XIW", "4HHB"])
-            response_json = requests.post(headers={"Content-Type": "application/json"}, json=query, url=const.DATA_API_ENDPOINT, timeout=config.API_TIMEOUT).json()
+            response_json = httpx.post(headers={"Content-Type": "application/json"}, json=query, url=const.DATA_API_ENDPOINT, timeout=config.API_TIMEOUT).json()
             logger.info("response: %r", response_json)
             self.assertNotIn("errors", response_json.keys())
 
@@ -300,7 +300,7 @@ class SchemaTests(unittest.TestCase):
                 return_data_list=["rcsb_struct_symmetry_lineage"],
                 input_ids=["4HHB-1", "MA_MACOFFESLACC100000G1I2-2"]
             )
-            response_json = requests.post(headers={"Content-Type": "application/json"}, json=query, url=const.DATA_API_ENDPOINT, timeout=config.API_TIMEOUT).json()
+            response_json = httpx.post(headers={"Content-Type": "application/json"}, json=query, url=const.DATA_API_ENDPOINT, timeout=config.API_TIMEOUT).json()
             logger.info("response: %r", response_json)
             self.assertNotIn("errors", response_json.keys())
 
@@ -310,7 +310,7 @@ class SchemaTests(unittest.TestCase):
             query = DATA_SCHEMA.construct_query(
                 input_type="interfaces", return_data_list=["rcsb_interface_container_identifiers.assembly_id"], input_ids=["MA_MACOFFESLACC100000G1I2-1.1", "7XIW-1.2"]
             )
-            response_json = requests.post(headers={"Content-Type": "application/json"}, json=query, url=const.DATA_API_ENDPOINT, timeout=config.API_TIMEOUT).json()
+            response_json = httpx.post(headers={"Content-Type": "application/json"}, json=query, url=const.DATA_API_ENDPOINT, timeout=config.API_TIMEOUT).json()
             logger.info("response: %r", response_json)
             self.assertNotIn("errors", response_json.keys())
 
@@ -318,7 +318,7 @@ class SchemaTests(unittest.TestCase):
         with self.subTest(msg=msg):
             logger.info("Running subtest %s", msg)
             query = DATA_SCHEMA.construct_query(input_type="entry", return_data_list=["exptl"], input_ids=["4HHB"])
-            response_json = requests.post(headers={"Content-Type": "application/json"}, json=query, url=const.DATA_API_ENDPOINT, timeout=config.API_TIMEOUT).json()
+            response_json = httpx.post(headers={"Content-Type": "application/json"}, json=query, url=const.DATA_API_ENDPOINT, timeout=config.API_TIMEOUT).json()
             logger.info("response: %r", response_json)
             self.assertNotIn("errors", response_json.keys())
             self.assertNotIn("errors", response_json.keys())

--- a/tests/test_search_query.py
+++ b/tests/test_search_query.py
@@ -16,7 +16,7 @@ import time
 import unittest
 import os
 from itertools import islice
-import requests
+import httpx
 from rcsbapi.const import const
 from rcsbapi.search import search_attributes as attrs
 from rcsbapi.search import group
@@ -192,7 +192,7 @@ class SearchTests(unittest.TestCase):
         try:
             set(session)
             ok = False
-        except requests.HTTPError:
+        except (httpx.RequestError, httpx.HTTPStatusError):
             ok = True
         self.assertTrue(ok)
         logger.info("Malformed query test results: ok : (%r)", ok)
@@ -742,7 +742,7 @@ class SearchTests(unittest.TestCase):
             resultL = list(q1())
             ok = len(resultL) > 100000
             logger.info("Large search resultL length: (%d) ok: (%r)", len(resultL), ok)
-        except requests.exceptions.HTTPError:
+        except (httpx.RequestError, httpx.HTTPStatusError):
             ok = False
         self.assertTrue(ok)
 
@@ -783,7 +783,7 @@ class SearchTests(unittest.TestCase):
                 .exec("assembly")
             resultL = list(query)
             ok = len(resultL) < 0  # set this to false as it should fail
-        except requests.exceptions.HTTPError:
+        except (httpx.RequestError, httpx.HTTPStatusError):
             ok = True
         self.assertTrue(ok)
         logger.info("Mismatch test: ok: (%r)", ok)
@@ -858,7 +858,7 @@ class SearchTests(unittest.TestCase):
         q2 = SeqMotifQuery("FFFFF", sequence_type="dna")  # test a DNA query, this should yield no results
         try:
             result = list(q2())
-        except requests.exceptions.HTTPError as e:
+        except (httpx.RequestError, httpx.HTTPStatusError) as e:
             logger.error("HTTPError occurred: %s", e)
             result = []
         ok = len(result) == 0
@@ -881,7 +881,7 @@ class SearchTests(unittest.TestCase):
         q5 = SeqMotifQuery("ATUAC")  # An rna query with T should yield no results
         try:
             result = list(q5())
-        except requests.exceptions.HTTPError as e:
+        except (httpx.RequestError, httpx.HTTPStatusError) as e:
             logger.error("HTTPError occurred: %s", e)
             result = []
         ok = len(result) == 0
@@ -900,7 +900,7 @@ class SearchTests(unittest.TestCase):
         try:
             q1 = SeqMotifQuery("AAAA", "nothing", "nothing")  # this should fail
             _ = list(q1())
-        except requests.exceptions.HTTPError:
+        except (httpx.RequestError, httpx.HTTPStatusError):
             ok = True
         self.assertTrue(ok)
         logger.info("SeqMotif Query with invalid parameters failed successfully: (%r)", ok)
@@ -1107,7 +1107,7 @@ class SearchTests(unittest.TestCase):
                                         file_url="https://files.rcsb.org/view/4HHB.cif",
                                         file_format="pdb")
             result = list(q11())
-        except requests.HTTPError:
+        except (httpx.RequestError, httpx.HTTPStatusError):
             ok = True
         self.assertTrue(ok)
         logger.info("File url query with wrong file format failed successfully : (%r)", ok)
@@ -1280,7 +1280,7 @@ class SearchTests(unittest.TestCase):
                                      descriptor_type="something",  # unsupported parameter
                                      match_type="something")  # unsupported parameter
             result = list(q9())
-        except requests.HTTPError:
+        except (httpx.RequestError, httpx.HTTPStatusError):
             ok = True
         self.assertTrue(ok)
         logger.info("Descriptor query type with invalid parameters failed successfully : (%r)", ok)
@@ -1369,7 +1369,7 @@ class SearchTests(unittest.TestCase):
         q9 = AttributeQuery("invalid_identifier", operator="exact_match", value="ERROR", service="textx")
         try:
             _ = q9()
-        except requests.HTTPError:
+        except (httpx.RequestError, httpx.HTTPStatusError):
             ok = True
         self.assertTrue(ok)
         logger.info("Counting results of Attribute query type with invalid parameters failed successfully : (%r)", ok)


### PR DESCRIPTION
- Switch from using `requests` to [`httpx`](https://www.python-httpx.org/) (Issue [#33](https://github.com/rcsb/py-rcsb-api/issues/33))
- Add asynchronous request support for Data API (`rcsbapi.data`) to speed up requests
- Adjust and add default settings to `rcsbapi.config` configuration
